### PR TITLE
Updates the README.org to point to Emacs 26.2

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ homebrew-core formula (see [[https://github.com/Homebrew/homebrew-core/pull/3607
 formula.
 
 This formula currently supports:
-- GNU Emacs 26.1
+- GNU Emacs 26.2
 - GNU Emacs HEAD (currently 27.x)
 
 No bottles are available.
@@ -23,7 +23,7 @@ No bottles are available.
 ** Installation
 You can install this formula using:
 
-*** GNU Emacs 26.1
+*** GNU Emacs 26.2
 #+begin_src bash
 brew tap daviderestivo/emacs-head
 brew install emacs-head --with-cocoa


### PR DESCRIPTION
I came here after I tried building emacs on a new Mac. I think this version of emacs is quite necessary for anyone like me who likes to use the GUI verison of emacs along with emacs daemon for quick launch. The defaults basically suck now, since the 
`brew install emacs` version supports the daemon mode but no GUI and the `brew cask install emacs` version doesn't support the daemon server mode.

I was trying to play with Emacs 26.2 when I came here from a Reddit post. Updating documentation so that the next set of frusterated users can find your work more easily. Cheers 🍻