### PR TITLE
Add --with-imagemagick option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,31 +6,49 @@ os:
 matrix:
   include:
     # Emacs 26.x on Sierra      (10.12)
-    - env: BUILD_OPTIONS=""
+    - env:
+        - BUILD_OPTIONS=""
+        - TEST_OPTIONS=""
       osx_image: xcode9.2
     # Emacs 26.x on High Sierra (10.13)
-    - env: BUILD_OPTIONS=""
+    - env:
+        - BUILD_OPTIONS=""
+        - TEST_OPTIONS=""
       osx_image: xcode10.1
     # Emacs 26.x on Mojave      (10.14)
-    - env: BUILD_OPTIONS=""
+    - env:
+        - BUILD_OPTIONS=""
+        - TEST_OPTIONS=""
       osx_image: xcode10.2
       # Emacs 26.x on Sierra    (10.12) - All options (imagemagick@6)
-    - env: BUILD_OPTIONS="--with-cocoa --with-no-frame-refocus --with-imagemagick@6 --with-multicolor-fonts"
+    - env:
+        - BUILD_OPTIONS="--with-cocoa --with-no-frame-refocus --with-imagemagick --with-multicolor-fonts"
+        - TEST_OPTIONS=""
       osx_image: xcode9.2
       # Emacs 27.x on Sierra    (10.12) - All options (imagemagick@7)
-    - env: BUILD_OPTIONS="--HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick@7 --with-jansson"
+    - env:
+        - BUILD_OPTIONS="--HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson"
+        - TEST_OPTIONS="--HEAD"
       osx_image: xcode9.2
     # Emacs 26.x on High Sierra (10.13) - All options (imagemagick@6)
-    - env: BUILD_OPTIONS="--with-cocoa --with-no-frame-refocus --with-imagemagick@6 --with-multicolor-fonts"
+    - env:
+        - BUILD_OPTIONS="--with-cocoa --with-no-frame-refocus --with-imagemagick --with-multicolor-fonts"
+        - TEST_OPTIONS=""
       osx_image: xcode10.1
     # Emacs 27.x on High Sierra (10.13) - All options (imagemagick@7)
-    - env: BUILD_OPTIONS="--HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick@7 --with-jansson"
+    - env:
+        - BUILD_OPTIONS="--HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson"
+        - TEST_OPTIONS="--HEAD"
       osx_image: xcode10.1
     # Emacs 26.x on Mojave      (10.14) - All options (imagemagick@6)
-    - env: BUILD_OPTIONS="--with-cocoa --with-no-frame-refocus --with-imagemagick@6 --with-multicolor-fonts"
+    - env:
+        - BUILD_OPTIONS="--with-cocoa --with-no-frame-refocus --with-imagemagick --with-multicolor-fonts"
+        - TEST_OPTIONS=""
       osx_image: xcode10.2
     # Emacs 27.x on Mojave      (10.14) - All options (imagemagick@7)
-    - env: BUILD_OPTIONS="--HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick@7 --with-jansson"
+    - env:
+        - BUILD_OPTIONS="--HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson"
+        - TEST_OPTIONS="--HEAD"
       osx_image: xcode10.2
 
   fast_finish: true
@@ -40,4 +58,4 @@ before_install:
 
 script:
   - travis_wait 60 brew install Formula/emacs-head.rb $BUILD_OPTIONS
-  - brew test Formula/emacs-head.rb
+  - brew test $TEST_OPTIONS Formula/emacs-head.rb

--- a/README.org
+++ b/README.org
@@ -44,8 +44,7 @@ The following compiling options are available:
 | --with-ctags            | Don't remove the ctags executable that GNU Emacs provides                    |
 | --with-dbus             | Build with dbus support                                                      |
 | --without-gnutls        | Disable gnutls support                                                       |
-| --with-imagemagick@6    | Build with imagemagick@6 support                                             |
-| --with-imagemagick@7    | Build with imagemagick@7 support (only HEAD)                                 |
+| --with-imagemagick      | Build with imagemagick support                                               |
 | --with-jansson          | Enable jansson support (only HEAD)                                           |
 | --without-librsvg       | Disable librsvg support                                                      |
 | --with-mailutils        | Build with mailutils support                                                 |


### PR DESCRIPTION
The two options --with-imagemagick@6 and --with-imagemagick@7 have been
removed. Now on, when GNU Emacs is compiled with imagemagick
support (--with-imagemagick), imagemagick@6 is used for GNU Emacs 26.x
and imagemagick@7 for GNU Emacs 27.x.