### PR TITLE
fix README formatting of options

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,7 +7,7 @@ Emacs Head is a GNU Emacs formula based on the original Homebrew
 =emacs= [[https://github.com/Homebrew/homebrew-core/blob/master/Formula/emacs.rb][formula]].
 
 ** Why yet another Homebrew Emacs formula?
-Since the option "--with-cocoa" is not available in the latest Emacs
+Since the option ~--with-cocoa~ is not available in the latest Emacs
 homebrew-core formula (see [[https://github.com/Homebrew/homebrew-core/pull/36070][pull request]]), I decided to build my own
 formula.
 
@@ -44,21 +44,21 @@ brew install emacs-head --HEAD --with-cocoa
 ** Compilation options
 The following compiling options are available:
 
-| Option                  | Description                                                                  |
-|-------------------------+------------------------------------------------------------------------------|
-| --with-cocoa            | Build a Cocoa version of GNU Emacs                                           |
-| --with-ctags            | Don't remove the ctags executable that GNU Emacs provides                    |
-| --with-dbus             | Build with dbus support                                                      |
-| --without-gnutls        | Disable gnutls support                                                       |
-| --with-imagemagick      | Build with imagemagick support                                               |
-| --with-jansson          | Enable jansson support (only HEAD)                                           |
-| --without-librsvg       | Disable librsvg support                                                      |
-| --with-mailutils        | Build with mailutils support                                                 |
-| --with-multicolor-fonts | Enable multicolor fonts support on macOS (only for Emacs 26.2)               |
-| --without-modules       | Disable dynamic modules support                                              |
-| --with-no-frame-refocus | Disables frame re-focus (ie. closing one frame does not refocus another one) |
-| --without-libxml2       | Disable libxml2 support                                                      |
-| --with-pdumper          | Enable pdumper support                                                       |
+| Option                    | Description                                                                  |
+|---------------------------+------------------------------------------------------------------------------|
+| ~--with-cocoa~            | Build a Cocoa version of GNU Emacs                                           |
+| ~--with-ctags~            | Don't remove the ctags executable that GNU Emacs provides                    |
+| ~--with-dbus~             | Build with dbus support                                                      |
+| ~--without-gnutls~        | Disable gnutls support                                                       |
+| ~--with-imagemagick~      | Build with imagemagick support                                               |
+| ~--with-jansson~          | Enable jansson support (only HEAD)                                           |
+| ~--without-librsvg~       | Disable librsvg support                                                      |
+| ~--with-mailutils~        | Build with mailutils support                                                 |
+| ~--with-multicolor-fonts~ | Enable multicolor fonts support on macOS (only for Emacs 26.2)               |
+| ~--without-modules~       | Disable dynamic modules support                                              |
+| ~--with-no-frame-refocus~ | Disables frame re-focus (ie. closing one frame does not refocus another one) |
+| ~--without-libxml2~       | Disable libxml2 support                                                      |
+| ~--with-pdumper~          | Enable pdumper support                                                       |
 
 For the terminal version only of GNU Emacs please omit "--with-cocoa".
 
@@ -68,7 +68,7 @@ By default:
 - libxml2
 - dynamic modules
 
-are enabled. If you want to disable them please use the above "--without-*" options.
+are enabled. If you want to disable them please use the above "~--without-*~" options.
 
 ** Collaborating
 If you are interested in collaborating please open a Pull Request.


### PR DESCRIPTION
In non-code formatting, GitHub converts "`--`" to "--" (en-dash). Made pasting options tricky :)