### PR TITLE
Remove jansson option and ad ligatures patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,37 +77,37 @@ jobs:
       osx_image: xcode11.5
     # Emacs 27.x on High Sierra (macOS 10.13 - xcode10.1) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1
     # Emacs 27.x on Mojave      (macOS 10.14 - xcode11.3) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.3
     # Emacs 27.x on Catalina   (macOS 10.15.4 - xcode11.5) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick  --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.5
     # Emacs 27.x on High Sierra (macOS 10.13 - xcode10.1) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1
     # Emacs 27.x on Mojave      (macOS 10.14 - xcode11.3) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.3
     # Emacs 27.x on Catalina  (macOS 10.15.4 - xcode11.5) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.5
@@ -117,37 +117,37 @@ jobs:
     ####################
     # Emacs 27.x (HEAD) on High Sierra (macOS 10.13 - xcode10.1) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1
     # Emacs 27.x (HEAD) on Mojave      (macOS 10.14 - xcode11.3) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD  --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD  --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.3
     # Emacs 27.x on Catalina           (macOS 10.15.4 - xcode11.5) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.5
     # Emacs 27.x (HEAD) on High Sierra (macOS 10.13 - xcode10.1) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb  --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb  --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1
     # Emacs 27.x (HEAD) on Mojave      (macOS 10.14 - xcode11.3) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.3
     # Emacs 27.x on Catalina           (macOS 10.15.4 - xcode11.5) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@27.rb --HEAD --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@27.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.5
@@ -157,37 +157,37 @@ jobs:
     ##############
     # Emacs 28.x on High Sierra (macOS 10.13 - xcode10.1) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="--verbose Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1
     # Emacs 28.x on Mojave      (macOS 10.14 - xcode11.3) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.3
     # Emacs 28.x on Catalina   (macOS 10.15.4 - xcode11.5) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.5
     # Emacs 28.x on High Sierra (macOS 10.13 - xcode10.1) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="--verbose Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1
     # Emacs 28.x on Mojave      (macOS 10.14 - xcode11.3) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
         - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.3
     # Emacs 28.x on Catalina   (macOS 10.15.4 - xcode11.5) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode11.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ jobs:
     ##############
     # Emacs 28.x on High Sierra (macOS 10.13 - xcode10.1) - All options except pdumper (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
+      - BUILD_OPTIONS="--verbose Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1
@@ -175,7 +175,7 @@ jobs:
       osx_image: xcode11.5
     # Emacs 28.x on High Sierra (macOS 10.13 - xcode10.1) - All options (imagemagick@7)
     - env:
-      - BUILD_OPTIONS="Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
+      - BUILD_OPTIONS="--verbose Formula/emacs-head@28.rb --with-cocoa --with-no-frame-refocus --with-imagemagick --with-jansson --with-pdumper --with-xwidgets"
       - TEST_OPTIONS="Formula/emacs-head@28.rb"
       - HOMEBREW_TRAVIS_BRANCH=$TRAVIS_BRANCH
       osx_image: xcode10.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -198,5 +198,12 @@ before_install:
   - brew update
 
 script:
-  - travis_wait 50 brew install $BUILD_OPTIONS
+  - |
+    # Prints a banner message every 9 mins to avoid travis build to
+    # fail in case a commands take longer than 10 mins. This is an
+    # alternative to travis_wait that does not log in case of failure.
+    while sleep 540; do
+      echo "===> [ $SECONDS seconds still running ] <==="
+    done &
+  - brew install $BUILD_OPTIONS
   - brew test $TEST_OPTIONS

--- a/Formula/emacs-head@27.rb
+++ b/Formula/emacs-head@27.rb
@@ -9,11 +9,11 @@ class EmacsHeadAT27 < Formula
   revision 1
 
   bottle do
-    rebuild 1
+    rebuild 2
     root_url "https://dl.bintray.com/daviderestivo/homebrew-emacs-head"
-    sha256 "9073566fd71f292386ef4cc4899c29d0a36b6c72f7a524bb8d2f9b4ab72d0e93" => :high_sierra
-    sha256 "1df58198642beff961cd2d25d4270278c666c0b2dc3573cca32ca913dd9dad91" => :mojave
-    sha256 "827c699b30de9a57ce7709d6fdf4d591b3b1d446915aab3e4c0933bee82e5ecd" => :catalina
+    sha256 "" => :high_sierra
+    sha256 "" => :mojave
+    sha256 "" => :catalina
   end
 
   head do

--- a/Formula/emacs-head@27.rb
+++ b/Formula/emacs-head@27.rb
@@ -194,6 +194,11 @@ class EmacsHeadAT27 < Formula
     sha256 "82252e2858a0eba95148661264e390eaf37349fec9c30881d3c1299bfaee8b21"
   end
 
+  patch do
+    url EmacsHeadAT27.get_resource_url("patches/0007-Ligatures-freeze-fix-27.patch")
+    sha256 "9f81669cba1dedb2733e95d49b8ebe82df3455bf258f130749665cc6adf2afa9"
+  end
+
   # All the patches are now downloaded unconditionally even if they
   # are not used in order to overcome the reinstall issue mentioned
   # here:
@@ -218,6 +223,12 @@ class EmacsHeadAT27 < Formula
   resource "0005-System-appearance-27" do
     url EmacsHeadAT27.get_resource_url("patches/0005-System-appearance-27.patch")
     sha256 "82252e2858a0eba95148661264e390eaf37349fec9c30881d3c1299bfaee8b21"
+  end
+
+  # Link: https://www.reddit.com/r/emacs/comments/icem4s/emacs_271_freezes_when_using_font_ligatures/
+  resource "0007-Ligatures-freeze-fix-27" do
+    url EmacsHeadAT27.get_resource_url("patches/0007-Ligatures-freeze-fix-27.patch")
+    sha256 "9f81669cba1dedb2733e95d49b8ebe82df3455bf258f130749665cc6adf2afa9"
   end
 
   # Icons

--- a/Formula/emacs-head@27.rb
+++ b/Formula/emacs-head@27.rb
@@ -50,8 +50,6 @@ class EmacsHeadAT27 < Formula
          "Disable gnutls support"
   option "with-imagemagick",
          "Build with imagemagick support"
-  option "with-jansson",
-         "Enable jansson support"
   option "without-librsvg",
          "Disable librsvg support"
   option "with-mailutils",
@@ -462,10 +460,6 @@ class EmacsHeadAT27 < Formula
       ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     else
       args << "--without-imagemagick"
-    end
-
-    if build.with? "jansson"
-      args << "--with-json"
     end
 
     args << "--with-modules"  unless build.without? "modules"

--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -36,8 +36,6 @@ class EmacsHeadAT28 < Formula
          "Disable gnutls support"
   option "with-imagemagick",
          "Build with imagemagick support"
-  option "with-jansson",
-         "Enable jansson support"
   option "without-librsvg",
          "Disable librsvg support"
   option "with-mailutils",
@@ -434,10 +432,6 @@ class EmacsHeadAT28 < Formula
       ENV.prepend_path "PKG_CONFIG_PATH", imagemagick_lib_path
     else
       args << "--without-imagemagick"
-    end
-
-    if build.with? "jansson"
-      args << "--with-json"
     end
 
     args << "--with-modules"  unless build.without? "modules"

--- a/README.org
+++ b/README.org
@@ -42,7 +42,6 @@ GNU Emacs 27.1 bottles have been built with the following options:
 --with-cocoa
 --with-no-frame-refocus
 --with-imagemagick (7)
---with-jansson
 --with-pdumper
 --with-xwidgets
 #+end_src
@@ -99,7 +98,6 @@ The following compilation options are available:
 | ~--with-dbus~             | Build with dbus support                                                      |
 | ~--without-gnutls~        | Disable gnutls support                                                       |
 | ~--with-imagemagick~      | Build with imagemagick support                                               |
-| ~--with-jansson~          | Enable jansson support (only for emacs-head@27 and emacs-head@28)            |
 | ~--without-librsvg~       | Disable librsvg support                                                      |
 | ~--with-mailutils~        | Build with mailutils support                                                 |
 | ~--with-multicolor-fonts~ | Enable multicolor fonts support on macOS (only for emacs-head)               |

--- a/patches/0007-Ligatures-freeze-fix-27.patch
+++ b/patches/0007-Ligatures-freeze-fix-27.patch
@@ -1,0 +1,38 @@
+From fe903c5ab7354b97f80ecf1b01ca3ff1027be446 Mon Sep 17 00:00:00 2001
+From: Eli Zaretskii <eliz@gnu.org>
+Date: Sat, 8 Feb 2020 15:41:36 +0200
+Subject: [PATCH] Allow composition of pure-ASCII strings in the mode line
+
+* src/composite.c (Fcomposition_get_gstring): Allow unibyte
+strings if they are pure ASCII, by copying text into a
+multibyte string.
+---
+ src/composite.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/composite.c b/src/composite.c
+index 53e6930b5f..05365cfb65 100644
+--- a/src/composite.c
++++ b/src/composite.c
+@@ -1746,7 +1746,18 @@ Otherwise (for terminal display), FONT-OBJECT must be a terminal ID, a
+       CHECK_STRING (string);
+       validate_subarray (string, from, to, SCHARS (string), &frompos, &topos);
+       if (! STRING_MULTIBYTE (string))
+-	error ("Attempt to shape unibyte text");
++	{
++	  ptrdiff_t i;
++
++	  for (i = SBYTES (string) - 1; i >= 0; i--)
++	    if (!ASCII_CHAR_P (SREF (string, i)))
++	      error ("Attempt to shape unibyte text");
++	  /* STRING is a pure-ASCII string, so we can convert it (or,
++	     rather, its copy) to multibyte and use that thereafter.  */
++	  Lisp_Object string_copy = Fconcat (1, &string);
++	  STRING_SET_MULTIBYTE (string_copy);
++	  string = string_copy;
++	}
+       frombyte = string_char_to_byte (string, frompos);
+     }
+ 
+-- 
+2.28.0


### PR DESCRIPTION
- Remove jansson option since it's a default now on GNU/Emacs 27 and 28
- Add patch to avoid GNU/Emacs 27.1 freezes when using font ligatures
- Replace travis_wait with a while/sleep loop