### PR TITLE
Update system appearance patches

### DIFF
--- a/Formula/emacs-head@27.rb
+++ b/Formula/emacs-head@27.rb
@@ -197,7 +197,7 @@ class EmacsHeadAT27 < Formula
 
   patch do
     url EmacsHeadAT27.get_resource_url("patches/0005-System-appearance-27.patch")
-    sha256 "a267a67956ded98b6337fb92e6f3830555b2fe70c3e6f7aa6c1697a7398428dc"
+    sha256 "e09078a03a6b55fc5cd0785b138f472dea7bbaf8123dadc04e5122155218c1e1"
   end
 
   patch do

--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -179,7 +179,7 @@ class EmacsHeadAT28 < Formula
 
   patch do
     url EmacsHeadAT28.get_resource_url("patches/0005-System-appearance.patch")
-    sha256 "b4ccc981e461ac12661fc4cf0ad7211a1dcab61dccf4bd4eee49ca5f7d66c496"
+    sha256 "4b17be19144997c3ae3456a707b4643bb7a6766eb0aec234973f3f0d77b1a893"
   end
 
   patch do

--- a/README.org
+++ b/README.org
@@ -126,19 +126,23 @@ mainly allows loading a different theme to better match the system
 appearance.
 
 #+begin_src elisp
-(add-hook 'ns-system-appearance-change-functions
-          #'(lambda (appearance)
-              (mapc #'disable-theme custom-enabled-themes)
-              (pcase appearance
-                ('light (load-theme 'tango t))
-                ('dark (load-theme 'tango-dark t)))))
+(defun my/apply-theme (appearance)
+  "Load theme, taking current system APPEARANCE into consideration."
+  (mapc #'disable-theme custom-enabled-themes)
+  (pcase appearance
+    ('light (load-theme 'tango t))
+    ('dark (load-theme 'tango-dark t))))
+
+(add-hook 'ns-system-appearance-change-functions #'my/apply-theme)
 #+end_src>
 
-Note that this hook is run early in the startup process, so if you
-want your theme to match the system appearance when GNU Emacs starts, you
-can register your function(s) in your early-init.el. The hook is NOT
-run in TTY sessions.
+Note that this hook is also run once when Emacs is initialized, so
+simply adding the above to your init.el will allow matching the system
+appearance upon startup. You can also determine what the current
+system appearance is by inspecting the value of the
+ns-system-appearance variable.
 
+The hook is NOT run in TTY Emacs sessions.
 ** Pdumper support
 The portable dumper is available in HEAD. To enable this feature
 please use ~--HEAD --with-pdumper~.

--- a/patches/0005-System-appearance-27.patch
+++ b/patches/0005-System-appearance-27.patch
@@ -1,6 +1,7 @@
-From f1488d050826e1d72866a63314d2dcd3617ff4ba Mon Sep 17 00:00:00 2001
+Patch to make emacs 27 aware of the macOS 10.14+ system appearance changes.
+From 43963fc1a2c37657067710243bfeda6c7dd06a67 Mon Sep 17 00:00:00 2001
 From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
-Date: Sat, 27 Jun 2020 18:04:38 +0200
+Date: Sun, 8 Nov 2020 19:07:31 +0100
 Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
 
 This implements a new hook, effective only on macOS >= 10.14 (Mojave),
@@ -32,23 +33,27 @@ macOS >= 10.14.
   - Add `ns-system-appearance-change-functions' hook variable and
     symbol, to allow users to add functions that react to the
     change of the system's appearance.
+  - Add `ns-system-appearance' variable, to allow users to consult
+    the current system appearance.
 
 Here is an example on how to use this new feature:
 
-    (add-hook 'ns-system-appearance-change-functions
-        #'(lambda (appearance)
-            (mapc #'disable-theme custom-enabled-themes)
-            (pcase appearance
-               ('light (load-theme 'tango t))
-               ('dark (load-theme 'tango-dark t)))))
+    (defun my/load-theme (appearance)
+      "Load theme, taking current system APPEARANCE into consideration."
+      (mapc #'disable-theme custom-enabled-themes)
+      (pcase appearance
+        ('light (load-theme 'tango t))
+        ('dark (load-theme 'tango-dark t))))
 
-The hook is executed once at Emacs startup, and then every time the
-system appearance changes.
+    (add-hook 'ns-system-appearance-change-functions #'my/load-theme)
+
+The hook being run on each system appearance change as well as at
+startup time, Emacs should then always load the appropriate theme.
 ---
  src/frame.h  |   1 +
- src/nsfns.m  |  13 +++++-
- src/nsterm.m | 122 +++++++++++++++++++++++++++++++++++++++++++++++----
- 3 files changed, 126 insertions(+), 10 deletions(-)
+ src/nsfns.m  |  13 ++++-
+ src/nsterm.m | 139 ++++++++++++++++++++++++++++++++++++++++++++++++---
+ 3 files changed, 143 insertions(+), 10 deletions(-)
 
 diff --git a/src/frame.h b/src/frame.h
 index a54b8623e5..46a7c34cb7 100644
@@ -89,7 +94,7 @@ index 0f879fe390..5a4dd3a157 100644
  
    tem = gui_display_get_arg (dpyinfo, parms, Qns_transparent_titlebar,
 diff --git a/src/nsterm.m b/src/nsterm.m
-index ac467840a2..0065bf66ab 100644
+index 3dd915e370..6dddd01c90 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
 @@ -2027,16 +2027,35 @@ so some key presses (TAB) are swallowed by the system.  */
@@ -140,7 +145,7 @@ index ac467840a2..0065bf66ab 100644
  
  @implementation EmacsApp
  
-@@ -5811,6 +5831,13 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
+@@ -5811,6 +5831,18 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
  	 object:nil];
  #endif
  
@@ -149,12 +154,17 @@ index ac467840a2..0065bf66ab 100644
 +         forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
 +            options:NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew
 +            context:&kEmacsAppKVOContext];
++
++  pending_funcalls = Fcons(list3(Qrun_hook_with_args,
++                                 Qns_system_appearance_change_functions,
++                                 Vns_system_appearance),
++                           pending_funcalls);
 +#endif
 +
  #ifdef NS_IMPL_COCOA
    /* Some functions/methods in CoreFoundation/Foundation increase the
       maximum number of open files for the process in their first call.
-@@ -5849,6 +5876,50 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+@@ -5849,6 +5881,54 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
  #endif
  }
  
@@ -195,17 +205,21 @@ index ac467840a2..0065bf66ab 100644
 +
 +  BOOL is_dark_appearance =
 +    [appearance_name isEqualToString:NSAppearanceNameDarkAqua];
++  Lisp_Object effective_appearance = is_dark_appearance ? Qdark : Qlight;
 +
-+  pending_funcalls = Fcons (list3 (Qrun_hook_with_args,
-+                                   Qns_system_appearance_change_functions,
-+                                   is_dark_appearance ? Qdark : Qlight),
-+                            pending_funcalls);
++  Vns_system_appearance = effective_appearance;
++
++  safe_call2 (Qrun_hook_with_args,
++              Qns_system_appearance_change_functions,
++              effective_appearance);
++
++  Fredisplay(Qnil);
 +#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
 +}
  
  /* Termination sequences:
      C-x C-c:
-@@ -6013,6 +6084,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+@@ -6013,6 +6093,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
    ns_send_appdefined (-1);
  }
  
@@ -220,7 +234,7 @@ index ac467840a2..0065bf66ab 100644
  
  
  /* ==========================================================================
-@@ -7492,12 +7571,27 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
+@@ -7492,12 +7580,27 @@ - (instancetype) initFrameFromEmacs: (struct frame *)f
  #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
  #ifndef NSAppKitVersionNumber10_10
  #define NSAppKitVersionNumber10_10 1343
@@ -252,17 +266,25 @@ index ac467840a2..0065bf66ab 100644
  #endif
  
  #if defined (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101000
-@@ -9606,6 +9700,18 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
+@@ -9606,6 +9709,26 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
  This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
    ns_use_mwheel_momentum = YES;
  
++  DEFVAR_LISP ("ns-system-appearance", Vns_system_appearance,
++               doc: /* Current system appearance, i.e. `dark' or `light'.
++
++This variable is ignored on macOS < 10.14 and GNUstep.  Default is nil.  */);
++  Vns_system_appearance = Qnil;
++  DEFSYM(Qns_system_appearance, "ns-system-appearance");
++
 +  DEFVAR_LISP ("ns-system-appearance-change-functions",
 +               Vns_system_appearance_change_functions,
 +     doc: /* List of functions to call when the system appearance changes.
 +Each function is called with a single argument, which corresponds to the new
 +system appearance (`dark' or `light').
 +
-+This hook is also run once at startup.
++This hook is also run once at startup, so that the initial system appearance
++can be taken into account.
 +
 +This variable is ignored on macOS < 10.14 and GNUstep.  Default is nil.  */);
 +  Vns_system_appearance_change_functions = Qnil;
@@ -272,5 +294,7 @@ index ac467840a2..0065bf66ab 100644
    DEFVAR_LISP ("x-toolkit-scroll-bars", Vx_toolkit_scroll_bars,
  	       doc: /* SKIP: real doc in xterm.c.  */);
 -- 
-2.27.0
+2.29.2
+
+
 

--- a/patches/0005-System-appearance.patch
+++ b/patches/0005-System-appearance.patch
@@ -1,6 +1,7 @@
-From 9428b506b6ae70dc7551ac0de364726584e536fe Mon Sep 17 00:00:00 2001
+Patch to make emacs 28 aware of the macOS 10.14+ system appearance changes.
+From 8c761f0a4cbd2952958ba3ac17e25ad8719b68d5 Mon Sep 17 00:00:00 2001
 From: "Nicolas G. Querol" <nicolas.gquerol@gmail.com>
-Date: Sat, 27 Jun 2020 18:04:38 +0200
+Date: Sun, 8 Nov 2020 21:53:21 +0100
 Subject: [PATCH] Add `ns-system-appearance-change-functions' hook
 
 This implements a new hook, effective only on macOS >= 10.14 (Mojave),
@@ -32,29 +33,34 @@ macOS >= 10.14.
   - Add `ns-system-appearance-change-functions' hook variable and
     symbol, to allow users to add functions that react to the
     change of the system's appearance.
+  - Add `ns-system-appearance' variable, to allow users to consult
+    the current system appearance.
 
 Here is an example on how to use this new feature:
 
-    (add-hook 'ns-system-appearance-change-functions
-        #'(lambda (appearance)
-            (mapc #'disable-theme custom-enabled-themes)
-            (pcase appearance
-               ('light (load-theme 'tango t))
-               ('dark (load-theme 'tango-dark t)))))
+    (defun my/apply-theme (appearance)
+      "Load theme, taking current system APPEARANCE into consideration."
+      (mapc #'disable-theme custom-enabled-themes)
+      (pcase appearance
+        ('light (load-theme 'tango t))
+        ('dark (load-theme 'tango-dark t))))
 
-The hook is executed once at Emacs startup, and then every time the
-system appearance changes.
+    (add-hook 'ns-system-appearance-change-functions #'my/apply-theme)
+
+The hook being run on each system appearance change as well as at startup
+time, Emacs should then always load the theme you chose for the current
+appearance.
 ---
  src/frame.h  |   3 +-
- src/nsfns.m  |  13 +++++-
- src/nsterm.m | 126 ++++++++++++++++++++++++++++++++++++++++++++-------
- 3 files changed, 124 insertions(+), 18 deletions(-)
+ src/nsfns.m  |  13 ++++-
+ src/nsterm.m | 142 +++++++++++++++++++++++++++++++++++++++++++++------
+ 3 files changed, 140 insertions(+), 18 deletions(-)
 
 diff --git a/src/frame.h b/src/frame.h
-index 476bac67fa..cb778d0135 100644
+index 16ecfd311c..b0dcb3098e 100644
 --- a/src/frame.h
 +++ b/src/frame.h
-@@ -71,7 +71,8 @@ enum ns_appearance_type
+@@ -71,7 +71,8 @@ #define EMACS_FRAME_H
    {
      ns_appearance_system_default,
      ns_appearance_aqua,
@@ -65,10 +71,10 @@ index 476bac67fa..cb778d0135 100644
  #endif
  #endif /* HAVE_WINDOW_SYSTEM */
 diff --git a/src/nsfns.m b/src/nsfns.m
-index 628233ea0d..a537d4b629 100644
+index c7956497c4..dcfc66e1dc 100644
 --- a/src/nsfns.m
 +++ b/src/nsfns.m
-@@ -1269,14 +1269,25 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
+@@ -1253,14 +1253,25 @@ Turn the input menu (an NSMenu) into a lisp list for tracking on lisp side.
    store_frame_param (f, Qundecorated, FRAME_UNDECORATED (f) ? Qt : Qnil);
  
  #ifdef NS_IMPL_COCOA
@@ -96,10 +102,10 @@ index 628233ea0d..a537d4b629 100644
                       (!NILP (tem) && !EQ (tem, Qunbound)) ? tem : Qnil);
  
 diff --git a/src/nsterm.m b/src/nsterm.m
-index 0699468dba..7f2b646870 100644
+index fa38350a2f..d8c3dcc2e3 100644
 --- a/src/nsterm.m
 +++ b/src/nsterm.m
-@@ -2203,13 +2203,25 @@ so some key presses (TAB) are swallowed by the system.  */
+@@ -2192,13 +2192,25 @@ so some key presses (TAB) are swallowed by the system.  */
      return;
  
    if (EQ (new_value, Qdark))
@@ -131,7 +137,7 @@ index 0699468dba..7f2b646870 100644
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
  }
  
-@@ -5672,6 +5684,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
+@@ -5737,6 +5749,7 @@ Needs to be here because ns_initialize_display_info () uses AppKit classes.
  
     ========================================================================== */
  
@@ -139,7 +145,7 @@ index 0699468dba..7f2b646870 100644
  
  @implementation EmacsApp
  
-@@ -5917,6 +5930,13 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
+@@ -5982,6 +5995,18 @@ - (void)applicationDidFinishLaunching: (NSNotification *)notification
  	 object:nil];
  #endif
  
@@ -148,12 +154,17 @@ index 0699468dba..7f2b646870 100644
 +         forKeyPath:NSStringFromSelector(@selector(effectiveAppearance))
 +            options:NSKeyValueObservingOptionInitial|NSKeyValueObservingOptionNew
 +            context:&kEmacsAppKVOContext];
++
++   pending_funcalls = Fcons(list3(Qrun_hook_with_args,
++                                  Qns_system_appearance_change_functions,
++                                  Vns_system_appearance),
++                            pending_funcalls);
 +#endif
 +
  #ifdef NS_IMPL_COCOA
    /* Some functions/methods in CoreFoundation/Foundation increase the
       maximum number of open files for the process in their first call.
-@@ -5955,6 +5975,50 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
+@@ -6020,6 +6045,54 @@ - (void)antialiasThresholdDidChange:(NSNotification *)notification
  #endif
  }
  
@@ -194,17 +205,21 @@ index 0699468dba..7f2b646870 100644
 +
 +  BOOL is_dark_appearance =
 +    [appearance_name isEqualToString:NSAppearanceNameDarkAqua];
++  Lisp_Object effective_appearance = is_dark_appearance ? Qdark : Qlight;
 +
-+  pending_funcalls = Fcons (list3 (Qrun_hook_with_args,
-+                                   Qns_system_appearance_change_functions,
-+                                   is_dark_appearance ? Qdark : Qlight),
-+                            pending_funcalls);
++  Vns_system_appearance = effective_appearance;
++
++  safe_call2 (Qrun_hook_with_args,
++              Qns_system_appearance_change_functions,
++              effective_appearance);
++
++  Fredisplay(Qnil);
 +#endif /* (NS_IMPL_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101400 */
 +}
  
  /* Termination sequences:
      C-x C-c:
-@@ -6119,6 +6183,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
+@@ -6184,6 +6257,14 @@ - (void)applicationDidResignActive: (NSNotification *)notification
    ns_send_appdefined (-1);
  }
  
@@ -219,7 +234,7 @@ index 0699468dba..7f2b646870 100644
  
  
  /* ==========================================================================
-@@ -8977,17 +9049,27 @@ - (void)setAppearance
+@@ -9035,17 +9116,27 @@ - (void)setAppearance
  #define NSAppKitVersionNumber10_10 1343
  #endif
  
@@ -257,10 +272,17 @@ index 0699468dba..7f2b646870 100644
  #endif /* MAC_OS_X_VERSION_MAX_ALLOWED >= 101000 */
  }
  
-@@ -9849,6 +9931,18 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
+@@ -9907,6 +9998,25 @@ Nil means use fullscreen the old (< 10.7) way.  The old way works better with
  This variable is ignored on macOS < 10.7 and GNUstep.  Default is t.  */);
    ns_use_mwheel_momentum = YES;
  
++ DEFVAR_LISP ("ns-system-appearance", Vns_system_appearance,
++               doc: /* Current system appearance, i.e. `dark' or `light'.
++
++This variable is ignored on macOS < 10.14 and GNUstep.  Default is nil.  */);
++  Vns_system_appearance = Qnil;
++  DEFSYM(Qns_system_appearance, "ns-system-appearance");
++
 +  DEFVAR_LISP ("ns-system-appearance-change-functions",
 +               Vns_system_appearance_change_functions,
 +     doc: /* List of functions to call when the system appearance changes.
@@ -277,5 +299,7 @@ index 0699468dba..7f2b646870 100644
    DEFVAR_LISP ("x-toolkit-scroll-bars", Vx_toolkit_scroll_bars,
  	       doc: /* SKIP: real doc in xterm.c.  */);
 -- 
-2.27.0
+2.29.2
+
+
 


### PR DESCRIPTION
- Force redisplay upon system appearance change so that new themes
  are visually immediately applied, even when Emacs is in the background

- Expose current system appearance through a new `ns-system-appearance'
  variable

See: https://github.com/d12frosted/homebrew-emacs-plus/commit/995548b402389bcf9745182195e8039a7a486cc9