### PR TITLE
Fix ELN file location change

### DIFF
--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -25,8 +25,6 @@ jobs:
       matrix:
         os: [macos-10.15, macos-11]
         build_opts:
-          # CLI version + native-comp
-          - '--with-pdumper --with-native-comp'
           # All options (imagemagick@7)
           - '--with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets'
           # All options (imagemagick@7) + native-comp support

--- a/.github/workflows/emacs-28.yml
+++ b/.github/workflows/emacs-28.yml
@@ -25,6 +25,8 @@ jobs:
       matrix:
         os: [macos-10.15, macos-11]
         build_opts:
+          # CLI version + native-comp
+          - '--with-pdumper --with-native-comp'
           # All options (imagemagick@7)
           - '--with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets'
           # All options (imagemagick@7) + native-comp support

--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -2,7 +2,7 @@
 class EmacsHeadAT28 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://github.com/emacs-mirror/emacs.git", revision: "4d63a033a726a8da33bda8d18a503e88bfb794fb"
+  url "https://github.com/emacs-mirror/emacs.git", revision: "6ec3cf1ccb5380acc376e89140b8d3a7fa4e471a"
   version "28.0.50"
   revision 1
 

--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -573,7 +573,6 @@ class EmacsHeadAT28 < Formula
       end
 
       system "make", *make_flags
-      system "make", "install"
 
       icons_dir = buildpath/"nextstep/Emacs.app/Contents/Resources"
 
@@ -611,18 +610,18 @@ class EmacsHeadAT28 < Formula
       end
 
       if build.with? "native-comp"
-        contents_dir = buildpath/"lib/emacs"
-
         # Change .eln files dylib ID to avoid that after the
         # post-install phase all of the *.eln files end up with the
         # same ID. See: https://github.com/Homebrew/brew/issues/9526
         # and https://github.com/Homebrew/brew/pull/10075
-        Dir.glob(contents_dir/"**/native-lisp/**/**/*.eln").each do |f|
+        Dir.glob(buildpath/"native-lisp/**/*.eln").each do |f|
           fo = MachO::MachOFile.new(f)
-          fo.dylib_id = "#{contents_dir}/" + f
+          fo.dylib_id = "#{buildpath}/" + f
           fo.write!
         end
       end
+
+      system "make", "install"
 
       # Install the (separate) debug symbol data that is generated
       # for the application

--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -2,7 +2,7 @@
 class EmacsHeadAT28 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://github.com/emacs-mirror/emacs.git", revision: "4d63a033a726a8da33bda8d18a503e88bfb794fb"
+  url "https://github.com/emacs-mirror/emacs.git"
   version "28.0.50"
   revision 1
 
@@ -611,15 +611,13 @@ class EmacsHeadAT28 < Formula
       end
 
       if build.with? "native-comp"
-        contents_dir = buildpath/"nextstep/Emacs.app/Contents"
-        contents_dir.install "native-lisp"
-        contents_dir.install "lisp"
+        contents_dir = buildpath/"lib/emacs"
 
         # Change .eln files dylib ID to avoid that after the
         # post-install phase all of the *.eln files end up with the
         # same ID. See: https://github.com/Homebrew/brew/issues/9526
         # and https://github.com/Homebrew/brew/pull/10075
-        Dir.glob(contents_dir/"native-lisp/**/*.eln").each do |f|
+        Dir.glob(contents_dir/"**/native-lisp/**/**/*.eln").each do |f|
           fo = MachO::MachOFile.new(f)
           fo.dylib_id = "#{contents_dir}/" + f
           fo.write!

--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -2,7 +2,7 @@
 class EmacsHeadAT28 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://github.com/emacs-mirror/emacs.git", revision: "6ec3cf1ccb5380acc376e89140b8d3a7fa4e471a"
+  url "https://github.com/emacs-mirror/emacs.git", revision: "4d63a033a726a8da33bda8d18a503e88bfb794fb"
   version "28.0.50"
   revision 1
 


### PR DESCRIPTION
GNU/Emacs commit 5dd2d50 has moved the native-lisp folder within self-containedb Emacs.app from: "Contents/Resources/native-lisp" to:  "Contents/MacOS/lib/emacs/28.0.50/native-lisp". This PR fixes ELN renaming for the new location.