### PR TITLE
emacs-29: fix libgccjit discovery patch

### DIFF
--- a/Formula/emacs-head@29.rb
+++ b/Formula/emacs-head@29.rb
@@ -197,6 +197,11 @@ class EmacsHeadAT29 < Formula
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
+  resource "0011-fix-MAC_LIBS-inference-after-gcc-12-release.patch" do
+    url EmacsHeadAT29.get_resource_url("patches/0011-fix-MAC_LIBS-inference-after-gcc-12-release.patch")
+    sha256 "4065671b2e89235aa579b1ae5a561fd59f1339edf9984986572681c08f61ebae"
+  end
+
   # Icons
   resource "modern-icon-sjrmanning" do
     url EmacsHeadAT29.get_resource_url("icons/modern-icon-sjrmanning.icns")
@@ -482,6 +487,11 @@ class EmacsHeadAT29 < Formula
   patch do
     url EmacsHeadAT29.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
+  end
+
+  patch do
+    url EmacsHeadAT29.get_resource_url("patches/0011-fix-MAC_LIBS-inference-after-gcc-12-release.patch")
+    sha256 "4065671b2e89235aa579b1ae5a561fd59f1339edf9984986572681c08f61ebae"
   end
 
   def install

--- a/patches/0011-fix-MAC_LIBS-inference-after-gcc-12-release.patch
+++ b/patches/0011-fix-MAC_LIBS-inference-after-gcc-12-release.patch
@@ -1,0 +1,26 @@
+From d3c9dcd4cb1d30a27e1e618ea5a9f5c12e103720 Mon Sep 17 00:00:00 2001
+From: Boris Buliga <boris@d12frosted.io>
+Date: Tue, 9 Aug 2022 09:17:27 +0300
+Subject: [PATCH] fix MAC_LIBS inference after gcc 12 release
+
+---
+ configure.ac | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1a264275bd..40777ba002 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4240,8 +4240,7 @@ if test "${with_native_compilation}" != "no"; then
+         if test -n "`$BREW --prefix --installed libgccjit 2>/dev/null`"; then
+           MAC_CFLAGS="-I$(dirname $($BREW ls -v libgccjit | \
+                                                 grep libgccjit.h))"
+-          MAC_LIBS="-L$(dirname $($BREW ls -v libgccjit| \
+-                                            grep -E 'libgccjit\.(so|dylib)$'))"
++          MAC_LIBS="-L$(dirname $($BREW ls -v libgccjit | grep -E 'libgccjit\.(so|dylib)$' | tail -1))"
+         fi
+       fi
+ 
+-- 
+2.36.1
+


### PR DESCRIPTION
Link: https://github.com/d12frosted/homebrew-emacs-plus/commit/ecaf5a621d9eeee29ea66c7b2952b50055662cf0