### PR TITLE
Emacs 28.2 released

### DIFF
--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -2,10 +2,10 @@
 class EmacsHeadAT28 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://ftp.gnu.org/gnu/emacs/emacs-28.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-28.1.tar.xz"
-  sha256 "28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1"
-  version "28.1"
+  url "https://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.xz"
+  mirror "https://ftpmirror.gnu.org/emacs/emacs-28.2.tar.xz"
+  sha256 "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488"
+  version "28.2"
   revision 1
 
   head do


### PR DESCRIPTION
https://lists.gnu.org/archive/html/emacs-devel/2022-09/msg00730.html