### PR TITLE
Refactor `get_resource_url` method adding support to local files

### DIFF
--- a/Formula/emacs-head@26.rb
+++ b/Formula/emacs-head@26.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require_relative "../Library/ResourcesResolver"
+
 class EmacsHeadAT26 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
@@ -148,15 +150,6 @@ class EmacsHeadAT26 < Formula
   option "with-retro-icon-sink",
          "Use a retro style icon by Erik Mugele"
 
-  def self.get_resource_url(resource)
-    if ENV['HOMEBREW_GITHUB_REF']
-      branch = ENV['HOMEBREW_GITHUB_REF'].sub("refs/heads/", "")
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + branch +  "/" + resource
-    else
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + "master" + "/" + resource
-    end
-  end
-
   # All the patches and the icons have been declared as resources.
   # They are downloaded unconditionally even if not used in order to
   # overcome the reinstall issue mentioned here:
@@ -164,284 +157,284 @@ class EmacsHeadAT26 < Formula
 
   # Patches
   resource "0001-No-frame-refocus-cocoa" do
-    url EmacsHeadAT26.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+    url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
     sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
   end
 
   resource "0002-Patch-multicolor-font" do
-    url EmacsHeadAT26.get_resource_url("patches/0002-Patch-multicolor-font.patch")
+    url ResourcesResolver.get_resource_url("patches/0002-Patch-multicolor-font.patch")
     sha256 "5af2587e986db70999d1a791fca58df027ccbabd75f45e4a2af1602c75511a8c"
   end
 
   resource "0006-Fix-unexec" do
-    url EmacsHeadAT26.get_resource_url("patches/0006-Fix-unexec.patch")
+    url ResourcesResolver.get_resource_url("patches/0006-Fix-unexec.patch")
     sha256 "a1fcfe8020301733a3846cf85b072b461b66e26d15b0154b978afb7a4ec3346b"
   end
 
   resource "0008-Fix-window-role.patch" do
-    url EmacsHeadAT26.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
   # Icons
   resource "modern-icon-sjrmanning" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-sjrmanning.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sjrmanning.icns")
     sha256 "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9"
   end
 
   resource "modern-icon-asingh4242" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-asingh4242.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-asingh4242.icns")
     sha256 "ff37bd9447550da54d90bfe5cb2173c93799d4c4d64f5a018cc6bfe6537517e4"
   end
 
   resource "modern-icon-paper-icons" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-paper-icons.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-paper-icons.icns")
     sha256 "209f7ea9e3b04d9b152e0580642e926d7e875bd1e33242616d266dd596f74c7a"
   end
 
   resource "modern-icon-azhilin" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-azhilin.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-azhilin.icns")
     sha256 "ee803f2d7a9ddd4d73ebb0561014b60d65f96947aa33633846aa2addace7a97a"
   end
 
   resource "modern-icon-mzaplotnik" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-mzaplotnik.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-mzaplotnik.icns")
     sha256 "1f77c52d3dbcdb0b869f47264ff3c2ac9f411e92ec71061a09771b7feac2ecc6"
   end
 
   resource "modern-icon-bananxan" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-bananxan.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bananxan.icns")
     sha256 "d7b4396fe667e2792c8755f85455635908091b812921890c4b0076488c880afc"
   end
 
   resource "modern-icon-vscode" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-vscode.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-vscode.icns")
     sha256 "5cfe371a1bbfd30c8c0bd9dba525a0625036a4c699996fb302cde294d35d0057"
   end
 
   resource "modern-icon-sexy-v1" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-sexy-v1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v1.icns")
     sha256 "1ea8515d1f6f225047be128009e53b9aa47a242e95823c07a67c6f8a26f8d820"
   end
 
   resource "modern-icon-sexy-v2" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-sexy-v2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v2.icns")
     sha256 "ecdc902435a8852d47e2c682810146e81f5ad72ee3d0c373c936eb4c1e0966e6"
   end
 
   resource "modern-icon-cg433n" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-cg433n.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-cg433n.icns")
     sha256 "9a0b101faa6ab543337179024b41a6e9ea0ecaf837fc8b606a19c6a51d2be5dd"
   end
 
   resource "modern-icon-purple" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-purple.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple.icns")
     sha256 "249e0b9f5c4abba008c34bec4e787b9df114229ee91d2724865e2c4da5790e3b"
   end
 
   resource "modern-icon-yellow" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-yellow.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-yellow.icns")
     sha256 "b7c39da6494ee20d41ec11f473dec8ebcab5406a4adbf8e74b601c2325b5eb7d"
   end
 
   resource "modern-icon-orange" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-orange.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-orange.icns")
     sha256 "e2f5d733f97b0a92a84b5fe0bcd4239937d8cb9de440d96e298b38d052e21b43"
   end
 
   resource "modern-icon-papirus" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-papirus.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-papirus.icns")
     sha256 "1ec7c6ddcec97e6182e4ffce6220796ee1cb0b5e00da40848713ce333337222b"
   end
 
   resource "modern-icon-pen" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-pen.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen.icns")
     sha256 "4fda050447a9803d38dd6fd7d35386103735aec239151714e8bf60bf9d357d3b"
   end
 
   resource "modern-icon-pen-3d" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-pen-3d.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-3d.icns")
     sha256 "ece20b691c8d61bb56e3a057345c1340c6c29f58f7798bcdc929c91d64e5599b"
   end
 
   resource "modern-icon-pen-lds56" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-pen-lds56.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-lds56.icns")
     sha256 "dd88972e2dd2d4dfd462825212967b33af3ec1cb38f2054a23db2ea657baa8a0"
   end
 
   resource "modern-icon-pen-black" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-pen-black.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-black.icns")
     sha256 "c4bf4de8aaf075d82fc363afbc480a1b8855776d0b61c3fc3a75e8063d7b5c27"
   end
 
   resource "modern-icon-black-variant" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-black-variant.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-variant.icns")
     sha256 "a56a19fb5195925c09f38708fd6a6c58c283a1725f7998e3574b0826c6d9ac7e"
   end
 
   resource "modern-icon-purple-flat" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-purple-flat.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple-flat.icns")
     sha256 "8468f0690efe308a4fe85c66bc3ed4902f8f984cf506318d5ef5759aa20d8bc6"
   end
 
   resource "modern-icon-spacemacs" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-spacemacs.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-spacemacs.icns")
     sha256 "9ee9464fcd436b6db676977143a306a572d0459dc882742e9bbc55a18f8940b9"
   end
 
   resource "modern-icon-alecive-flatwoken" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
     sha256 "779373dd240aa532248ac2918da3db0207afaa004f157fa790110eef2e216ccd"
   end
 
   resource "modern-icon-elrumo1" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-elrumo1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo1.icns")
     sha256 "f0900babe3d36b4660a4757ac1fa8abbb6e2978f4a4f2d18fa3c7ab1613e9d42"
   end
 
   resource "modern-icon-elrumo2" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-elrumo2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo2.icns")
     sha256 "0fbdab5172421d8235d9c53518dc294efbb207a4903b42a1e9a18212e6bae4f4"
   end
 
   resource "modern-icon-savchenkovaleriy-big-sur" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
     sha256 "975288f91608bf38ba55ad7a13502dc74dacf647f2e2f7eb336d7d470cc9e16d"
   end
 
   resource "modern-icon-bokehlicia-captiva" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
     sha256 "8534f309b72812ba99375ebe2eb1d814bd68aec8898add2896594f4eecb10238"
   end
 
   resource "modern-icon-nuvola" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-nuvola.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-nuvola.icns")
     sha256 "c3701e25ff46116fd694bc37d8ccec7ad9ae58bb581063f0792ea3c50d84d997"
   end
 
   resource "modern-icon-black-gnu-head" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-black-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-gnu-head.icns")
     sha256 "9ac25aaa986b53d268e94d24bb878689c290b237a7810790dead9162e6ddf54b"
   end
 
   resource "modern-icon-dragon" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-dragon.icns")
     sha256 "a0a624e6a08971f2f9220d2a3aaa79e1f8aecc85df8a522ebb40310c54699c40"
   end
 
   resource "modern-icon-black-dragon" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-black-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-dragon.icns")
     sha256 "2844b2e57f87d9bd183c572d24c8e5a5eb8ecfc238a8714d2c6e3ea51659c92a"
   end
 
   resource "modern-icon-emacs-icon1" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
     sha256 "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0"
   end
 
   resource "modern-icon-emacs-icon2" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
     sha256 "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963"
   end
 
   resource "modern-icon-emacs-icon3" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
     sha256 "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf"
   end
 
   resource "modern-icon-emacs-icon4" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
     sha256 "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135"
   end
 
   resource "modern-icon-emacs-icon5" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
     sha256 "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778"
   end
 
   resource "modern-icon-emacs-icon6" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
     sha256 "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0"
   end
 
   resource "modern-icon-emacs-icon7" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
     sha256 "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c"
   end
 
   resource "modern-icon-emacs-icon8" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
     sha256 "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0"
   end
 
   resource "modern-icon-emacs-icon9" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
     sha256 "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e"
   end
 
   resource "modern-icon-emacs-card-blue-deep" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
     sha256 "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9"
   end
 
   resource "modern-icon-emacs-card-british-racing-green" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
     sha256 "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5"
   end
 
   resource "modern-icon-emacs-card-carmine" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
     sha256 "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9"
   end
 
   resource "modern-icon-emacs-card-green" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-emacs-card-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-green.icns")
     sha256 "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7"
   end
 
   resource "modern-icon-doom" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-doom.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom.icns")
     sha256 "39378a10b3d7e804461eec8bb9967de0cec7b8f1151150bbe2ba16f21001722b"
   end
 
   resource "modern-icon-doom3" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-doom3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom3.icns")
     sha256 "3ac398d8d691687320d3a88cd8e634c8cfb7ca358bfe6c30108667f2486438b3"
   end
 
   resource "modern-icon-doom-cacodemon" do
-    url EmacsHeadAT26.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
     sha256 "5a8d53896f72992bc7158aaaa47665df4009be646deee39af6f8e76893568728"
   end
 
   resource "retro-icon-emacs-logo" do
-    url EmacsHeadAT26.get_resource_url("icons/retro-icon-emacs-logo.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-emacs-logo.icns")
     sha256 "0d7100faa68c17d012fe9309f9496b8d530946c324cb7598c93a4c425326ff97"
   end
 
   resource "retro-icon-gnu-head" do
-    url EmacsHeadAT26.get_resource_url("icons/retro-icon-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-head.icns")
     sha256 "cfca2ff0214cff47167f634a5b9f8c402b488796f79ded23f93ec505f78b2f2f"
   end
 
   resource "retro-icon-gnu-meditate-levitate" do
-    url EmacsHeadAT26.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
     sha256 "5424582f0a4c1998aa91eb8185e1d41961cbc9605dbcea8a037c602587b14998"
   end
 
   resource "retro-icon-sink-bw" do
-    url EmacsHeadAT26.get_resource_url("icons/retro-icon-sink-bw.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink-bw.icns")
     sha256 "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571"
   end
 
   resource "retro-icon-sink" do
-    url EmacsHeadAT26.get_resource_url("icons/retro-icon-sink.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink.icns")
     sha256 "be0ee790589a3e49345e1894050678eab2c75272a8d927db46e240a2466c6abc"
   end
 
   # https://github.com/emacs-mirror/emacs/commit/888ffd960c06d56a409a7ff15b1d930d25c56089
   patch do
-    url EmacsHeadAT26.get_resource_url("patches/0006-Fix-unexec.patch")
+    url ResourcesResolver.get_resource_url("patches/0006-Fix-unexec.patch")
     sha256 "a1fcfe8020301733a3846cf85b072b461b66e26d15b0154b978afb7a4ec3346b"
   end
 
@@ -453,7 +446,7 @@ class EmacsHeadAT26 < Formula
   # Reference: https://github.com/d12frosted/homebrew-emacs-plus/issues/119
   if build.with? "no-frame-refocus"
     patch do
-      url EmacsHeadAT26.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+      url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
       sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
     end
   end
@@ -461,13 +454,13 @@ class EmacsHeadAT26 < Formula
   # Enable multicolor-fonts support
   if  build.with? "multicolor-fonts"
     patch do
-      url EmacsHeadAT26.get_resource_url("patches/0002-Patch-multicolor-font.patch")
+      url ResourcesResolver.get_resource_url("patches/0002-Patch-multicolor-font.patch")
       sha256 "5af2587e986db70999d1a791fca58df027ccbabd75f45e4a2af1602c75511a8c"
     end
   end
 
   patch do
-    url EmacsHeadAT26.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 

--- a/Formula/emacs-head@27.rb
+++ b/Formula/emacs-head@27.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require_relative "../Library/ResourcesResolver"
+
 class EmacsHeadAT27 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
@@ -157,15 +159,6 @@ class EmacsHeadAT27 < Formula
   option "with-retro-icon-sink",
          "Use a retro style icon by Erik Mugele"
 
-  def self.get_resource_url(resource)
-    if ENV['HOMEBREW_GITHUB_REF']
-      branch = ENV['HOMEBREW_GITHUB_REF'].sub("refs/heads/", "")
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + branch +  "/" + resource
-    else
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + "master" + "/" + resource
-    end
-  end
-
   # All the patches and the icons have been declared as resources.
   # They are downloaded unconditionally even if not used in order to
   # overcome the reinstall issue mentioned here:
@@ -173,294 +166,294 @@ class EmacsHeadAT27 < Formula
 
   # Patches
   resource "0001-No-frame-refocus-cocoa" do
-    url EmacsHeadAT27.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+    url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
     sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
   end
 
   resource "0003-Pdumper-size-increase" do
-    url EmacsHeadAT27.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+    url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
     sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
   end
 
   resource "0004-Xwidgets-webkit-in-cocoa-27" do
-    url EmacsHeadAT27.get_resource_url("patches/0004-Xwidgets-webkit-in-cocoa-27.patch")
+    url ResourcesResolver.get_resource_url("patches/0004-Xwidgets-webkit-in-cocoa-27.patch")
     sha256 "56406c03cbcea0d6d4c893074935404937cdae03259b8120b1b913971a948476"
   end
 
   resource "0005-System-appearance-27" do
-    url EmacsHeadAT27.get_resource_url("patches/0005-System-appearance-27.patch")
+    url ResourcesResolver.get_resource_url("patches/0005-System-appearance-27.patch")
     sha256 "d774e9da082352999fe3e9d2daa1065ea9bdaa670267caeebf86e01a77dc1d40"
   end
 
   # Link: https://www.reddit.com/r/emacs/comments/icem4s/emacs_271_freezes_when_using_font_ligatures/
   resource "0007-Ligatures-freeze-fix-27" do
-    url EmacsHeadAT27.get_resource_url("patches/0007-Ligatures-freeze-fix-27.patch")
+    url ResourcesResolver.get_resource_url("patches/0007-Ligatures-freeze-fix-27.patch")
     sha256 "9f81669cba1dedb2733e95d49b8ebe82df3455bf258f130749665cc6adf2afa9"
   end
 
   resource "0008-Fix-window-role.patch" do
-    url EmacsHeadAT27.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
   resource "0010-Arm.patch" do
-    url EmacsHeadAT27.get_resource_url("patches/0010-Arm.patch")
+    url ResourcesResolver.get_resource_url("patches/0010-Arm.patch")
     sha256 "344fee330fec4071e29c900093fdf1e2d8a7328df1c75b17e6e9d9a954835741"
   end
 
   # Icons
   resource "modern-icon-sjrmanning" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-sjrmanning.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sjrmanning.icns")
     sha256 "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9"
   end
 
   resource "modern-icon-asingh4242" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-asingh4242.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-asingh4242.icns")
     sha256 "ff37bd9447550da54d90bfe5cb2173c93799d4c4d64f5a018cc6bfe6537517e4"
   end
 
   resource "modern-icon-paper-icons" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-paper-icons.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-paper-icons.icns")
     sha256 "209f7ea9e3b04d9b152e0580642e926d7e875bd1e33242616d266dd596f74c7a"
   end
 
   resource "modern-icon-azhilin" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-azhilin.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-azhilin.icns")
     sha256 "ee803f2d7a9ddd4d73ebb0561014b60d65f96947aa33633846aa2addace7a97a"
   end
 
   resource "modern-icon-mzaplotnik" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-mzaplotnik.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-mzaplotnik.icns")
     sha256 "1f77c52d3dbcdb0b869f47264ff3c2ac9f411e92ec71061a09771b7feac2ecc6"
   end
 
   resource "modern-icon-bananxan" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-bananxan.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bananxan.icns")
     sha256 "d7b4396fe667e2792c8755f85455635908091b812921890c4b0076488c880afc"
   end
 
   resource "modern-icon-vscode" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-vscode.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-vscode.icns")
     sha256 "5cfe371a1bbfd30c8c0bd9dba525a0625036a4c699996fb302cde294d35d0057"
   end
 
   resource "modern-icon-sexy-v1" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-sexy-v1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v1.icns")
     sha256 "1ea8515d1f6f225047be128009e53b9aa47a242e95823c07a67c6f8a26f8d820"
   end
 
   resource "modern-icon-sexy-v2" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-sexy-v2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v2.icns")
     sha256 "ecdc902435a8852d47e2c682810146e81f5ad72ee3d0c373c936eb4c1e0966e6"
   end
 
   resource "modern-icon-cg433n" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-cg433n.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-cg433n.icns")
     sha256 "9a0b101faa6ab543337179024b41a6e9ea0ecaf837fc8b606a19c6a51d2be5dd"
   end
 
   resource "modern-icon-purple" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-purple.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple.icns")
     sha256 "249e0b9f5c4abba008c34bec4e787b9df114229ee91d2724865e2c4da5790e3b"
   end
 
   resource "modern-icon-yellow" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-yellow.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-yellow.icns")
     sha256 "b7c39da6494ee20d41ec11f473dec8ebcab5406a4adbf8e74b601c2325b5eb7d"
   end
 
   resource "modern-icon-orange" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-orange.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-orange.icns")
     sha256 "e2f5d733f97b0a92a84b5fe0bcd4239937d8cb9de440d96e298b38d052e21b43"
   end
 
   resource "modern-icon-papirus" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-papirus.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-papirus.icns")
     sha256 "1ec7c6ddcec97e6182e4ffce6220796ee1cb0b5e00da40848713ce333337222b"
   end
 
   resource "modern-icon-pen" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-pen.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen.icns")
     sha256 "4fda050447a9803d38dd6fd7d35386103735aec239151714e8bf60bf9d357d3b"
   end
 
   resource "modern-icon-pen-3d" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-pen-3d.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-3d.icns")
     sha256 "ece20b691c8d61bb56e3a057345c1340c6c29f58f7798bcdc929c91d64e5599b"
   end
 
   resource "modern-icon-pen-lds56" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-pen-lds56.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-lds56.icns")
     sha256 "dd88972e2dd2d4dfd462825212967b33af3ec1cb38f2054a23db2ea657baa8a0"
   end
 
   resource "modern-icon-pen-black" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-pen-black.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-black.icns")
     sha256 "c4bf4de8aaf075d82fc363afbc480a1b8855776d0b61c3fc3a75e8063d7b5c27"
   end
 
   resource "modern-icon-black-variant" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-black-variant.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-variant.icns")
     sha256 "a56a19fb5195925c09f38708fd6a6c58c283a1725f7998e3574b0826c6d9ac7e"
   end
 
   resource "modern-icon-purple-flat" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-purple-flat.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple-flat.icns")
     sha256 "8468f0690efe308a4fe85c66bc3ed4902f8f984cf506318d5ef5759aa20d8bc6"
   end
 
   resource "modern-icon-spacemacs" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-spacemacs.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-spacemacs.icns")
     sha256 "9ee9464fcd436b6db676977143a306a572d0459dc882742e9bbc55a18f8940b9"
   end
 
   resource "modern-icon-alecive-flatwoken" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
     sha256 "779373dd240aa532248ac2918da3db0207afaa004f157fa790110eef2e216ccd"
   end
 
   resource "modern-icon-elrumo1" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-elrumo1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo1.icns")
     sha256 "f0900babe3d36b4660a4757ac1fa8abbb6e2978f4a4f2d18fa3c7ab1613e9d42"
   end
 
   resource "modern-icon-elrumo2" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-elrumo2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo2.icns")
     sha256 "0fbdab5172421d8235d9c53518dc294efbb207a4903b42a1e9a18212e6bae4f4"
   end
 
   resource "modern-icon-savchenkovaleriy-big-sur" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
     sha256 "975288f91608bf38ba55ad7a13502dc74dacf647f2e2f7eb336d7d470cc9e16d"
   end
 
   resource "modern-icon-bokehlicia-captiva" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
     sha256 "8534f309b72812ba99375ebe2eb1d814bd68aec8898add2896594f4eecb10238"
   end
 
   resource "modern-icon-nuvola" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-nuvola.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-nuvola.icns")
     sha256 "c3701e25ff46116fd694bc37d8ccec7ad9ae58bb581063f0792ea3c50d84d997"
   end
 
   resource "modern-icon-black-gnu-head" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-black-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-gnu-head.icns")
     sha256 "9ac25aaa986b53d268e94d24bb878689c290b237a7810790dead9162e6ddf54b"
   end
 
   resource "modern-icon-dragon" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-dragon.icns")
     sha256 "a0a624e6a08971f2f9220d2a3aaa79e1f8aecc85df8a522ebb40310c54699c40"
   end
 
   resource "modern-icon-black-dragon" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-black-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-dragon.icns")
     sha256 "2844b2e57f87d9bd183c572d24c8e5a5eb8ecfc238a8714d2c6e3ea51659c92a"
   end
 
   resource "modern-icon-emacs-icon1" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
     sha256 "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0"
   end
 
   resource "modern-icon-emacs-icon2" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
     sha256 "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963"
   end
 
   resource "modern-icon-emacs-icon3" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
     sha256 "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf"
   end
 
   resource "modern-icon-emacs-icon4" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
     sha256 "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135"
   end
 
   resource "modern-icon-emacs-icon5" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
     sha256 "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778"
   end
 
   resource "modern-icon-emacs-icon6" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
     sha256 "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0"
   end
 
   resource "modern-icon-emacs-icon7" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
     sha256 "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c"
   end
 
   resource "modern-icon-emacs-icon8" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
     sha256 "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0"
   end
 
   resource "modern-icon-emacs-icon9" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
     sha256 "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e"
   end
 
   resource "modern-icon-emacs-card-blue-deep" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
     sha256 "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9"
   end
 
   resource "modern-icon-emacs-card-british-racing-green" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
     sha256 "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5"
   end
 
   resource "modern-icon-emacs-card-carmine" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
     sha256 "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9"
   end
 
   resource "modern-icon-emacs-card-green" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-emacs-card-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-green.icns")
     sha256 "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7"
   end
 
   resource "modern-icon-doom" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-doom.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom.icns")
     sha256 "39378a10b3d7e804461eec8bb9967de0cec7b8f1151150bbe2ba16f21001722b"
   end
 
   resource "modern-icon-doom3" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-doom3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom3.icns")
     sha256 "3ac398d8d691687320d3a88cd8e634c8cfb7ca358bfe6c30108667f2486438b3"
   end
 
   resource "modern-icon-doom-cacodemon" do
-    url EmacsHeadAT27.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
     sha256 "5a8d53896f72992bc7158aaaa47665df4009be646deee39af6f8e76893568728"
   end
 
   resource "retro-icon-emacs-logo" do
-    url EmacsHeadAT27.get_resource_url("icons/retro-icon-emacs-logo.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-emacs-logo.icns")
     sha256 "0d7100faa68c17d012fe9309f9496b8d530946c324cb7598c93a4c425326ff97"
   end
 
   resource "retro-icon-gnu-head" do
-    url EmacsHeadAT27.get_resource_url("icons/retro-icon-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-head.icns")
     sha256 "cfca2ff0214cff47167f634a5b9f8c402b488796f79ded23f93ec505f78b2f2f"
   end
 
   resource "retro-icon-gnu-meditate-levitate" do
-    url EmacsHeadAT27.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
     sha256 "5424582f0a4c1998aa91eb8185e1d41961cbc9605dbcea8a037c602587b14998"
   end
 
   resource "retro-icon-sink-bw" do
-    url EmacsHeadAT27.get_resource_url("icons/retro-icon-sink-bw.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink-bw.icns")
     sha256 "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571"
   end
 
   resource "retro-icon-sink" do
-    url EmacsHeadAT27.get_resource_url("icons/retro-icon-sink.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink.icns")
     sha256 "be0ee790589a3e49345e1894050678eab2c75272a8d927db46e240a2466c6abc"
   end
 
@@ -472,14 +465,14 @@ class EmacsHeadAT27 < Formula
   # Reference: https://github.com/d12frosted/homebrew-emacs-plus/issues/119
   if build.with? "no-frame-refocus"
     patch do
-      url EmacsHeadAT27.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+      url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
       sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
     end
   end
 
   if build.with? "pdumper"
     patch do
-      url EmacsHeadAT27.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+      url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
       sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
     end
   end
@@ -489,23 +482,23 @@ class EmacsHeadAT27 < Formula
       odie "--with-xwidgets is supported only on cocoa via xwidget webkit"
     end
     patch do
-      url EmacsHeadAT27.get_resource_url("patches/0004-Xwidgets-webkit-in-cocoa-27.patch")
+      url ResourcesResolver.get_resource_url("patches/0004-Xwidgets-webkit-in-cocoa-27.patch")
       sha256 "56406c03cbcea0d6d4c893074935404937cdae03259b8120b1b913971a948476"
     end
   end
 
   patch do
-    url EmacsHeadAT27.get_resource_url("patches/0005-System-appearance-27.patch")
+    url ResourcesResolver.get_resource_url("patches/0005-System-appearance-27.patch")
     sha256 "d774e9da082352999fe3e9d2daa1065ea9bdaa670267caeebf86e01a77dc1d40"
   end
 
   patch do
-    url EmacsHeadAT27.get_resource_url("patches/0007-Ligatures-freeze-fix-27.patch")
+    url ResourcesResolver.get_resource_url("patches/0007-Ligatures-freeze-fix-27.patch")
     sha256 "9f81669cba1dedb2733e95d49b8ebe82df3455bf258f130749665cc6adf2afa9"
   end
 
   patch do
-    url EmacsHeadAT27.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
@@ -513,7 +506,7 @@ class EmacsHeadAT27 < Formula
     # Back-ported patch for configure and configure.guess to allow
     # configure to complete for aarch64-apple-darwin targets.
     patch do
-      url EmacsHeadAT27.get_resource_url("patches/0010-Arm.patch")
+      url ResourcesResolver.get_resource_url("patches/0010-Arm.patch")
       sha256 "344fee330fec4071e29c900093fdf1e2d8a7328df1c75b17e6e9d9a954835741"
     end
   end

--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require_relative "../Library/ResourcesResolver"
+
 class EmacsHeadAT28 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
@@ -170,15 +172,6 @@ class EmacsHeadAT28 < Formula
     depends_on "libgccjit" => :recommended
   end
 
-  def self.get_resource_url(resource)
-    if ENV['HOMEBREW_GITHUB_REF']
-      branch = ENV['HOMEBREW_GITHUB_REF'].sub("refs/heads/", "")
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + branch +  "/" + resource
-    else
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + "master" + "/" + resource
-    end
-  end
-
   # All the patches and the icons have been declared as resources.
   # They are downloaded unconditionally even if not used in order to
   # overcome the reinstall issue mentioned here:
@@ -186,278 +179,278 @@ class EmacsHeadAT28 < Formula
 
   # Patches
   resource "0001-No-frame-refocus-cocoa" do
-    url EmacsHeadAT28.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+    url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
     sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
   end
 
   resource "0003-Pdumper-size-increase" do
-    url EmacsHeadAT28.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+    url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
     sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
   end
 
   resource "0005-System-appearance" do
-    url  EmacsHeadAT28.get_resource_url("patches/0005-System-appearance.patch")
+    url  ResourcesResolver.get_resource_url("patches/0005-System-appearance.patch")
     sha256 "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   end
 
   resource "0008-Fix-window-role.patch" do
-    url EmacsHeadAT28.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
   # Icons
   resource "modern-icon-sjrmanning" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-sjrmanning.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sjrmanning.icns")
     sha256 "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9"
   end
 
   resource "modern-icon-asingh4242" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-asingh4242.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-asingh4242.icns")
     sha256 "ff37bd9447550da54d90bfe5cb2173c93799d4c4d64f5a018cc6bfe6537517e4"
   end
 
   resource "modern-icon-paper-icons" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-paper-icons.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-paper-icons.icns")
     sha256 "209f7ea9e3b04d9b152e0580642e926d7e875bd1e33242616d266dd596f74c7a"
   end
 
   resource "modern-icon-azhilin" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-azhilin.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-azhilin.icns")
     sha256 "ee803f2d7a9ddd4d73ebb0561014b60d65f96947aa33633846aa2addace7a97a"
   end
 
   resource "modern-icon-mzaplotnik" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-mzaplotnik.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-mzaplotnik.icns")
     sha256 "1f77c52d3dbcdb0b869f47264ff3c2ac9f411e92ec71061a09771b7feac2ecc6"
   end
 
   resource "modern-icon-bananxan" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-bananxan.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bananxan.icns")
     sha256 "d7b4396fe667e2792c8755f85455635908091b812921890c4b0076488c880afc"
   end
 
   resource "modern-icon-vscode" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-vscode.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-vscode.icns")
     sha256 "5cfe371a1bbfd30c8c0bd9dba525a0625036a4c699996fb302cde294d35d0057"
   end
 
   resource "modern-icon-sexy-v1" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-sexy-v1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v1.icns")
     sha256 "1ea8515d1f6f225047be128009e53b9aa47a242e95823c07a67c6f8a26f8d820"
   end
 
   resource "modern-icon-sexy-v2" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-sexy-v2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v2.icns")
     sha256 "ecdc902435a8852d47e2c682810146e81f5ad72ee3d0c373c936eb4c1e0966e6"
   end
 
   resource "modern-icon-cg433n" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-cg433n.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-cg433n.icns")
     sha256 "9a0b101faa6ab543337179024b41a6e9ea0ecaf837fc8b606a19c6a51d2be5dd"
   end
 
   resource "modern-icon-purple" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-purple.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple.icns")
     sha256 "249e0b9f5c4abba008c34bec4e787b9df114229ee91d2724865e2c4da5790e3b"
   end
 
   resource "modern-icon-yellow" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-yellow.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-yellow.icns")
     sha256 "b7c39da6494ee20d41ec11f473dec8ebcab5406a4adbf8e74b601c2325b5eb7d"
   end
 
   resource "modern-icon-orange" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-orange.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-orange.icns")
     sha256 "e2f5d733f97b0a92a84b5fe0bcd4239937d8cb9de440d96e298b38d052e21b43"
   end
 
   resource "modern-icon-papirus" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-papirus.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-papirus.icns")
     sha256 "1ec7c6ddcec97e6182e4ffce6220796ee1cb0b5e00da40848713ce333337222b"
   end
 
   resource "modern-icon-pen" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-pen.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen.icns")
     sha256 "4fda050447a9803d38dd6fd7d35386103735aec239151714e8bf60bf9d357d3b"
   end
 
   resource "modern-icon-pen-3d" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-pen-3d.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-3d.icns")
     sha256 "ece20b691c8d61bb56e3a057345c1340c6c29f58f7798bcdc929c91d64e5599b"
   end
 
   resource "modern-icon-pen-lds56" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-pen-lds56.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-lds56.icns")
     sha256 "dd88972e2dd2d4dfd462825212967b33af3ec1cb38f2054a23db2ea657baa8a0"
   end
 
   resource "modern-icon-pen-black" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-pen-black.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-black.icns")
     sha256 "c4bf4de8aaf075d82fc363afbc480a1b8855776d0b61c3fc3a75e8063d7b5c27"
   end
 
   resource "modern-icon-black-variant" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-black-variant.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-variant.icns")
     sha256 "a56a19fb5195925c09f38708fd6a6c58c283a1725f7998e3574b0826c6d9ac7e"
   end
 
   resource "modern-icon-purple-flat" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-purple-flat.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple-flat.icns")
     sha256 "8468f0690efe308a4fe85c66bc3ed4902f8f984cf506318d5ef5759aa20d8bc6"
   end
 
   resource "modern-icon-spacemacs" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-spacemacs.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-spacemacs.icns")
     sha256 "9ee9464fcd436b6db676977143a306a572d0459dc882742e9bbc55a18f8940b9"
   end
 
   resource "modern-icon-alecive-flatwoken" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
     sha256 "779373dd240aa532248ac2918da3db0207afaa004f157fa790110eef2e216ccd"
   end
 
   resource "modern-icon-elrumo1" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-elrumo1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo1.icns")
     sha256 "f0900babe3d36b4660a4757ac1fa8abbb6e2978f4a4f2d18fa3c7ab1613e9d42"
   end
 
   resource "modern-icon-elrumo2" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-elrumo2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo2.icns")
     sha256 "0fbdab5172421d8235d9c53518dc294efbb207a4903b42a1e9a18212e6bae4f4"
   end
 
   resource "modern-icon-savchenkovaleriy-big-sur" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
     sha256 "975288f91608bf38ba55ad7a13502dc74dacf647f2e2f7eb336d7d470cc9e16d"
   end
 
   resource "modern-icon-bokehlicia-captiva" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
     sha256 "8534f309b72812ba99375ebe2eb1d814bd68aec8898add2896594f4eecb10238"
   end
 
   resource "modern-icon-nuvola" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-nuvola.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-nuvola.icns")
     sha256 "c3701e25ff46116fd694bc37d8ccec7ad9ae58bb581063f0792ea3c50d84d997"
   end
 
   resource "modern-icon-black-gnu-head" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-black-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-gnu-head.icns")
     sha256 "9ac25aaa986b53d268e94d24bb878689c290b237a7810790dead9162e6ddf54b"
   end
 
   resource "modern-icon-dragon" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-dragon.icns")
     sha256 "a0a624e6a08971f2f9220d2a3aaa79e1f8aecc85df8a522ebb40310c54699c40"
   end
 
   resource "modern-icon-black-dragon" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-black-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-dragon.icns")
     sha256 "2844b2e57f87d9bd183c572d24c8e5a5eb8ecfc238a8714d2c6e3ea51659c92a"
   end
 
   resource "modern-icon-emacs-icon1" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
     sha256 "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0"
   end
 
   resource "modern-icon-emacs-icon2" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
     sha256 "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963"
   end
 
   resource "modern-icon-emacs-icon3" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
     sha256 "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf"
   end
 
   resource "modern-icon-emacs-icon4" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
     sha256 "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135"
   end
 
   resource "modern-icon-emacs-icon5" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
     sha256 "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778"
   end
 
   resource "modern-icon-emacs-icon6" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
     sha256 "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0"
   end
 
   resource "modern-icon-emacs-icon7" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
     sha256 "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c"
   end
 
   resource "modern-icon-emacs-icon8" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
     sha256 "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0"
   end
 
   resource "modern-icon-emacs-icon9" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
     sha256 "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e"
   end
 
   resource "modern-icon-emacs-card-blue-deep" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
     sha256 "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9"
   end
 
   resource "modern-icon-emacs-card-british-racing-green" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
     sha256 "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5"
   end
 
   resource "modern-icon-emacs-card-carmine" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
     sha256 "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9"
   end
 
   resource "modern-icon-emacs-card-green" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-emacs-card-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-green.icns")
     sha256 "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7"
   end
 
   resource "modern-icon-doom" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-doom.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom.icns")
     sha256 "39378a10b3d7e804461eec8bb9967de0cec7b8f1151150bbe2ba16f21001722b"
   end
 
   resource "modern-icon-doom3" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-doom3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom3.icns")
     sha256 "3ac398d8d691687320d3a88cd8e634c8cfb7ca358bfe6c30108667f2486438b3"
   end
 
   resource "modern-icon-doom-cacodemon" do
-    url EmacsHeadAT28.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
     sha256 "5a8d53896f72992bc7158aaaa47665df4009be646deee39af6f8e76893568728"
   end
 
   resource "retro-icon-emacs-logo" do
-    url EmacsHeadAT28.get_resource_url("icons/retro-icon-emacs-logo.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-emacs-logo.icns")
     sha256 "0d7100faa68c17d012fe9309f9496b8d530946c324cb7598c93a4c425326ff97"
   end
 
   resource "retro-icon-gnu-head" do
-    url EmacsHeadAT28.get_resource_url("icons/retro-icon-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-head.icns")
     sha256 "cfca2ff0214cff47167f634a5b9f8c402b488796f79ded23f93ec505f78b2f2f"
   end
 
   resource "retro-icon-gnu-meditate-levitate" do
-    url EmacsHeadAT28.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
     sha256 "5424582f0a4c1998aa91eb8185e1d41961cbc9605dbcea8a037c602587b14998"
   end
 
   resource "retro-icon-sink-bw" do
-    url EmacsHeadAT28.get_resource_url("icons/retro-icon-sink-bw.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink-bw.icns")
     sha256 "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571"
   end
 
   resource "retro-icon-sink" do
-    url EmacsHeadAT28.get_resource_url("icons/retro-icon-sink.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink.icns")
     sha256 "be0ee790589a3e49345e1894050678eab2c75272a8d927db46e240a2466c6abc"
   end
 
@@ -469,14 +462,14 @@ class EmacsHeadAT28 < Formula
   # Reference: https://github.com/d12frosted/homebrew-emacs-plus/issues/119
   if build.with? "no-frame-refocus"
     patch do
-      url EmacsHeadAT28.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+      url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
       sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
     end
   end
 
   if build.with? "pdumper"
     patch do
-      url EmacsHeadAT28.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+      url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
       sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
     end
   end
@@ -488,12 +481,12 @@ class EmacsHeadAT28 < Formula
   end
 
   patch do
-    url EmacsHeadAT28.get_resource_url("patches/0005-System-appearance.patch")
+    url ResourcesResolver.get_resource_url("patches/0005-System-appearance.patch")
     sha256 "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   end
 
   patch do
-    url EmacsHeadAT28.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 

--- a/Formula/emacs-head@29.rb
+++ b/Formula/emacs-head@29.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require_relative "../Library/ResourcesResolver"
+
 class EmacsHeadAT29 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
@@ -178,15 +180,6 @@ class EmacsHeadAT29 < Formula
     depends_on "tree-sitter" => :optional
   end
 
-  def self.get_resource_url(resource)
-    if ENV['HOMEBREW_GITHUB_REF']
-      branch = ENV['HOMEBREW_GITHUB_REF'].sub("refs/heads/", "")
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + branch +  "/" + resource
-    else
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + "master" + "/" + resource
-    end
-  end
-
   # All the patches and the icons have been declared as resources.
   # They are downloaded unconditionally even if not used in order to
   # overcome the reinstall issue mentioned here:
@@ -194,283 +187,283 @@ class EmacsHeadAT29 < Formula
 
   # Patches
   resource "0001-No-frame-refocus-cocoa" do
-    url EmacsHeadAT29.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+    url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
     sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
   end
 
   resource "0003-Pdumper-size-increase" do
-    url EmacsHeadAT29.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+    url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
     sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
   end
 
   resource "0005-System-appearance" do
-    url  EmacsHeadAT29.get_resource_url("patches/0005-System-appearance.patch")
+    url  ResourcesResolver.get_resource_url("patches/0005-System-appearance.patch")
     sha256 "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   end
 
   resource "0008-Fix-window-role.patch" do
-    url EmacsHeadAT29.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
   resource "0011-Poll.patch" do
-    url EmacsHeadAT29.get_resource_url("patches/0011-Poll.patch")
+    url ResourcesResolver.get_resource_url("patches/0011-Poll.patch")
     sha256 "052eacac5b7bd86b466f9a3d18bff9357f2b97517f463a09e4c51255bdb14648"
   end
 
   # Icons
   resource "modern-icon-sjrmanning" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-sjrmanning.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sjrmanning.icns")
     sha256 "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9"
   end
 
   resource "modern-icon-asingh4242" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-asingh4242.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-asingh4242.icns")
     sha256 "ff37bd9447550da54d90bfe5cb2173c93799d4c4d64f5a018cc6bfe6537517e4"
   end
 
   resource "modern-icon-paper-icons" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-paper-icons.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-paper-icons.icns")
     sha256 "209f7ea9e3b04d9b152e0580642e926d7e875bd1e33242616d266dd596f74c7a"
   end
 
   resource "modern-icon-azhilin" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-azhilin.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-azhilin.icns")
     sha256 "ee803f2d7a9ddd4d73ebb0561014b60d65f96947aa33633846aa2addace7a97a"
   end
 
   resource "modern-icon-mzaplotnik" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-mzaplotnik.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-mzaplotnik.icns")
     sha256 "1f77c52d3dbcdb0b869f47264ff3c2ac9f411e92ec71061a09771b7feac2ecc6"
   end
 
   resource "modern-icon-bananxan" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-bananxan.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bananxan.icns")
     sha256 "d7b4396fe667e2792c8755f85455635908091b812921890c4b0076488c880afc"
   end
 
   resource "modern-icon-vscode" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-vscode.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-vscode.icns")
     sha256 "5cfe371a1bbfd30c8c0bd9dba525a0625036a4c699996fb302cde294d35d0057"
   end
 
   resource "modern-icon-sexy-v1" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-sexy-v1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v1.icns")
     sha256 "1ea8515d1f6f225047be128009e53b9aa47a242e95823c07a67c6f8a26f8d820"
   end
 
   resource "modern-icon-sexy-v2" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-sexy-v2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v2.icns")
     sha256 "ecdc902435a8852d47e2c682810146e81f5ad72ee3d0c373c936eb4c1e0966e6"
   end
 
   resource "modern-icon-cg433n" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-cg433n.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-cg433n.icns")
     sha256 "9a0b101faa6ab543337179024b41a6e9ea0ecaf837fc8b606a19c6a51d2be5dd"
   end
 
   resource "modern-icon-purple" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-purple.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple.icns")
     sha256 "249e0b9f5c4abba008c34bec4e787b9df114229ee91d2724865e2c4da5790e3b"
   end
 
   resource "modern-icon-yellow" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-yellow.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-yellow.icns")
     sha256 "b7c39da6494ee20d41ec11f473dec8ebcab5406a4adbf8e74b601c2325b5eb7d"
   end
 
   resource "modern-icon-orange" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-orange.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-orange.icns")
     sha256 "e2f5d733f97b0a92a84b5fe0bcd4239937d8cb9de440d96e298b38d052e21b43"
   end
 
   resource "modern-icon-papirus" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-papirus.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-papirus.icns")
     sha256 "1ec7c6ddcec97e6182e4ffce6220796ee1cb0b5e00da40848713ce333337222b"
   end
 
   resource "modern-icon-pen" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-pen.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen.icns")
     sha256 "4fda050447a9803d38dd6fd7d35386103735aec239151714e8bf60bf9d357d3b"
   end
 
   resource "modern-icon-pen-3d" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-pen-3d.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-3d.icns")
     sha256 "ece20b691c8d61bb56e3a057345c1340c6c29f58f7798bcdc929c91d64e5599b"
   end
 
   resource "modern-icon-pen-lds56" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-pen-lds56.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-lds56.icns")
     sha256 "dd88972e2dd2d4dfd462825212967b33af3ec1cb38f2054a23db2ea657baa8a0"
   end
 
   resource "modern-icon-pen-black" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-pen-black.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-black.icns")
     sha256 "c4bf4de8aaf075d82fc363afbc480a1b8855776d0b61c3fc3a75e8063d7b5c27"
   end
 
   resource "modern-icon-black-variant" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-black-variant.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-variant.icns")
     sha256 "a56a19fb5195925c09f38708fd6a6c58c283a1725f7998e3574b0826c6d9ac7e"
   end
 
   resource "modern-icon-purple-flat" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-purple-flat.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple-flat.icns")
     sha256 "8468f0690efe308a4fe85c66bc3ed4902f8f984cf506318d5ef5759aa20d8bc6"
   end
 
   resource "modern-icon-spacemacs" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-spacemacs.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-spacemacs.icns")
     sha256 "9ee9464fcd436b6db676977143a306a572d0459dc882742e9bbc55a18f8940b9"
   end
 
   resource "modern-icon-alecive-flatwoken" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
     sha256 "779373dd240aa532248ac2918da3db0207afaa004f157fa790110eef2e216ccd"
   end
 
   resource "modern-icon-elrumo1" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-elrumo1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo1.icns")
     sha256 "f0900babe3d36b4660a4757ac1fa8abbb6e2978f4a4f2d18fa3c7ab1613e9d42"
   end
 
   resource "modern-icon-elrumo2" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-elrumo2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo2.icns")
     sha256 "0fbdab5172421d8235d9c53518dc294efbb207a4903b42a1e9a18212e6bae4f4"
   end
 
   resource "modern-icon-savchenkovaleriy-big-sur" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
     sha256 "975288f91608bf38ba55ad7a13502dc74dacf647f2e2f7eb336d7d470cc9e16d"
   end
 
   resource "modern-icon-bokehlicia-captiva" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
     sha256 "8534f309b72812ba99375ebe2eb1d814bd68aec8898add2896594f4eecb10238"
   end
 
   resource "modern-icon-nuvola" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-nuvola.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-nuvola.icns")
     sha256 "c3701e25ff46116fd694bc37d8ccec7ad9ae58bb581063f0792ea3c50d84d997"
   end
 
   resource "modern-icon-black-gnu-head" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-black-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-gnu-head.icns")
     sha256 "9ac25aaa986b53d268e94d24bb878689c290b237a7810790dead9162e6ddf54b"
   end
 
   resource "modern-icon-dragon" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-dragon.icns")
     sha256 "a0a624e6a08971f2f9220d2a3aaa79e1f8aecc85df8a522ebb40310c54699c40"
   end
 
   resource "modern-icon-black-dragon" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-black-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-dragon.icns")
     sha256 "2844b2e57f87d9bd183c572d24c8e5a5eb8ecfc238a8714d2c6e3ea51659c92a"
   end
 
   resource "modern-icon-emacs-icon1" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
     sha256 "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0"
   end
 
   resource "modern-icon-emacs-icon2" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
     sha256 "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963"
   end
 
   resource "modern-icon-emacs-icon3" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
     sha256 "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf"
   end
 
   resource "modern-icon-emacs-icon4" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
     sha256 "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135"
   end
 
   resource "modern-icon-emacs-icon5" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
     sha256 "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778"
   end
 
   resource "modern-icon-emacs-icon6" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
     sha256 "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0"
   end
 
   resource "modern-icon-emacs-icon7" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
     sha256 "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c"
   end
 
   resource "modern-icon-emacs-icon8" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
     sha256 "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0"
   end
 
   resource "modern-icon-emacs-icon9" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
     sha256 "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e"
   end
 
   resource "modern-icon-emacs-card-blue-deep" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
     sha256 "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9"
   end
 
   resource "modern-icon-emacs-card-british-racing-green" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
     sha256 "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5"
   end
 
   resource "modern-icon-emacs-card-carmine" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
     sha256 "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9"
   end
 
   resource "modern-icon-emacs-card-green" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-emacs-card-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-green.icns")
     sha256 "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7"
   end
 
   resource "modern-icon-doom" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-doom.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom.icns")
     sha256 "39378a10b3d7e804461eec8bb9967de0cec7b8f1151150bbe2ba16f21001722b"
   end
 
   resource "modern-icon-doom3" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-doom3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom3.icns")
     sha256 "3ac398d8d691687320d3a88cd8e634c8cfb7ca358bfe6c30108667f2486438b3"
   end
 
   resource "modern-icon-doom-cacodemon" do
-    url EmacsHeadAT29.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
     sha256 "5a8d53896f72992bc7158aaaa47665df4009be646deee39af6f8e76893568728"
   end
 
   resource "retro-icon-emacs-logo" do
-    url EmacsHeadAT29.get_resource_url("icons/retro-icon-emacs-logo.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-emacs-logo.icns")
     sha256 "0d7100faa68c17d012fe9309f9496b8d530946c324cb7598c93a4c425326ff97"
   end
 
   resource "retro-icon-gnu-head" do
-    url EmacsHeadAT29.get_resource_url("icons/retro-icon-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-head.icns")
     sha256 "cfca2ff0214cff47167f634a5b9f8c402b488796f79ded23f93ec505f78b2f2f"
   end
 
   resource "retro-icon-gnu-meditate-levitate" do
-    url EmacsHeadAT29.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
     sha256 "5424582f0a4c1998aa91eb8185e1d41961cbc9605dbcea8a037c602587b14998"
   end
 
   resource "retro-icon-sink-bw" do
-    url EmacsHeadAT29.get_resource_url("icons/retro-icon-sink-bw.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink-bw.icns")
     sha256 "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571"
   end
 
   resource "retro-icon-sink" do
-    url EmacsHeadAT29.get_resource_url("icons/retro-icon-sink.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink.icns")
     sha256 "be0ee790589a3e49345e1894050678eab2c75272a8d927db46e240a2466c6abc"
   end
 
@@ -482,14 +475,14 @@ class EmacsHeadAT29 < Formula
   # Reference: https://github.com/d12frosted/homebrew-emacs-plus/issues/119
   if build.with? "no-frame-refocus"
     patch do
-      url EmacsHeadAT29.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+      url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
       sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
     end
   end
 
   if build.with? "pdumper"
     patch do
-      url EmacsHeadAT29.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+      url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
       sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
     end
   end
@@ -502,18 +495,18 @@ class EmacsHeadAT29 < Formula
 
   if build.with? "poll"
     patch do
-      url EmacsHeadAT29.get_resource_url("patches/0011-Poll.patch")
+      url ResourcesResolver.get_resource_url("patches/0011-Poll.patch")
       sha256 "052eacac5b7bd86b466f9a3d18bff9357f2b97517f463a09e4c51255bdb14648"
     end
   end
 
   patch do
-    url EmacsHeadAT29.get_resource_url("patches/0005-System-appearance.patch")
+    url ResourcesResolver.get_resource_url("patches/0005-System-appearance.patch")
     sha256 "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   end
 
   patch do
-    url EmacsHeadAT29.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 

--- a/Formula/emacs-head@30.rb
+++ b/Formula/emacs-head@30.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+require_relative "../Library/ResourcesResolver"
+
 class EmacsHeadAT30 < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
@@ -172,15 +174,6 @@ class EmacsHeadAT30 < Formula
     depends_on "tree-sitter" => :optional
   end
 
-  def self.get_resource_url(resource)
-    if ENV['HOMEBREW_GITHUB_REF']
-      branch = ENV['HOMEBREW_GITHUB_REF'].sub("refs/heads/", "")
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + branch +  "/" + resource
-    else
-      "https://raw.githubusercontent.com/daviderestivo/homebrew-emacs-head/" + "master" + "/" + resource
-    end
-  end
-
   # All the patches and the icons have been declared as resources.
   # They are downloaded unconditionally even if not used in order to
   # overcome the reinstall issue mentioned here:
@@ -188,283 +181,283 @@ class EmacsHeadAT30 < Formula
 
   # Patches
   resource "0001-No-frame-refocus-cocoa" do
-    url EmacsHeadAT30.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+    url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
     sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
   end
 
   resource "0003-Pdumper-size-increase" do
-    url EmacsHeadAT30.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+    url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
     sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
   end
 
   resource "0005-System-appearance" do
-    url  EmacsHeadAT30.get_resource_url("patches/0005-System-appearance.patch")
+    url  ResourcesResolver.get_resource_url("patches/0005-System-appearance.patch")
     sha256 "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   end
 
   resource "0008-Fix-window-role.patch" do
-    url EmacsHeadAT30.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
   resource "0011-Poll.patch" do
-    url EmacsHeadAT30.get_resource_url("patches/0011-Poll.patch")
+    url ResourcesResolver.get_resource_url("patches/0011-Poll.patch")
     sha256 "052eacac5b7bd86b466f9a3d18bff9357f2b97517f463a09e4c51255bdb14648"
   end
 
   # Icons
   resource "modern-icon-sjrmanning" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-sjrmanning.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sjrmanning.icns")
     sha256 "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9"
   end
 
   resource "modern-icon-asingh4242" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-asingh4242.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-asingh4242.icns")
     sha256 "ff37bd9447550da54d90bfe5cb2173c93799d4c4d64f5a018cc6bfe6537517e4"
   end
 
   resource "modern-icon-paper-icons" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-paper-icons.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-paper-icons.icns")
     sha256 "209f7ea9e3b04d9b152e0580642e926d7e875bd1e33242616d266dd596f74c7a"
   end
 
   resource "modern-icon-azhilin" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-azhilin.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-azhilin.icns")
     sha256 "ee803f2d7a9ddd4d73ebb0561014b60d65f96947aa33633846aa2addace7a97a"
   end
 
   resource "modern-icon-mzaplotnik" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-mzaplotnik.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-mzaplotnik.icns")
     sha256 "1f77c52d3dbcdb0b869f47264ff3c2ac9f411e92ec71061a09771b7feac2ecc6"
   end
 
   resource "modern-icon-bananxan" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-bananxan.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bananxan.icns")
     sha256 "d7b4396fe667e2792c8755f85455635908091b812921890c4b0076488c880afc"
   end
 
   resource "modern-icon-vscode" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-vscode.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-vscode.icns")
     sha256 "5cfe371a1bbfd30c8c0bd9dba525a0625036a4c699996fb302cde294d35d0057"
   end
 
   resource "modern-icon-sexy-v1" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-sexy-v1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v1.icns")
     sha256 "1ea8515d1f6f225047be128009e53b9aa47a242e95823c07a67c6f8a26f8d820"
   end
 
   resource "modern-icon-sexy-v2" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-sexy-v2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-sexy-v2.icns")
     sha256 "ecdc902435a8852d47e2c682810146e81f5ad72ee3d0c373c936eb4c1e0966e6"
   end
 
   resource "modern-icon-cg433n" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-cg433n.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-cg433n.icns")
     sha256 "9a0b101faa6ab543337179024b41a6e9ea0ecaf837fc8b606a19c6a51d2be5dd"
   end
 
   resource "modern-icon-purple" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-purple.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple.icns")
     sha256 "249e0b9f5c4abba008c34bec4e787b9df114229ee91d2724865e2c4da5790e3b"
   end
 
   resource "modern-icon-yellow" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-yellow.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-yellow.icns")
     sha256 "b7c39da6494ee20d41ec11f473dec8ebcab5406a4adbf8e74b601c2325b5eb7d"
   end
 
   resource "modern-icon-orange" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-orange.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-orange.icns")
     sha256 "e2f5d733f97b0a92a84b5fe0bcd4239937d8cb9de440d96e298b38d052e21b43"
   end
 
   resource "modern-icon-papirus" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-papirus.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-papirus.icns")
     sha256 "1ec7c6ddcec97e6182e4ffce6220796ee1cb0b5e00da40848713ce333337222b"
   end
 
   resource "modern-icon-pen" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-pen.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen.icns")
     sha256 "4fda050447a9803d38dd6fd7d35386103735aec239151714e8bf60bf9d357d3b"
   end
 
   resource "modern-icon-pen-3d" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-pen-3d.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-3d.icns")
     sha256 "ece20b691c8d61bb56e3a057345c1340c6c29f58f7798bcdc929c91d64e5599b"
   end
 
   resource "modern-icon-pen-lds56" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-pen-lds56.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-lds56.icns")
     sha256 "dd88972e2dd2d4dfd462825212967b33af3ec1cb38f2054a23db2ea657baa8a0"
   end
 
   resource "modern-icon-pen-black" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-pen-black.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-pen-black.icns")
     sha256 "c4bf4de8aaf075d82fc363afbc480a1b8855776d0b61c3fc3a75e8063d7b5c27"
   end
 
   resource "modern-icon-black-variant" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-black-variant.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-variant.icns")
     sha256 "a56a19fb5195925c09f38708fd6a6c58c283a1725f7998e3574b0826c6d9ac7e"
   end
 
   resource "modern-icon-purple-flat" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-purple-flat.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-purple-flat.icns")
     sha256 "8468f0690efe308a4fe85c66bc3ed4902f8f984cf506318d5ef5759aa20d8bc6"
   end
 
   resource "modern-icon-spacemacs" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-spacemacs.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-spacemacs.icns")
     sha256 "9ee9464fcd436b6db676977143a306a572d0459dc882742e9bbc55a18f8940b9"
   end
 
   resource "modern-icon-alecive-flatwoken" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-alecive-flatwoken.icns")
     sha256 "779373dd240aa532248ac2918da3db0207afaa004f157fa790110eef2e216ccd"
   end
 
   resource "modern-icon-elrumo1" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-elrumo1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo1.icns")
     sha256 "f0900babe3d36b4660a4757ac1fa8abbb6e2978f4a4f2d18fa3c7ab1613e9d42"
   end
 
   resource "modern-icon-elrumo2" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-elrumo2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-elrumo2.icns")
     sha256 "0fbdab5172421d8235d9c53518dc294efbb207a4903b42a1e9a18212e6bae4f4"
   end
 
   resource "modern-icon-savchenkovaleriy-big-sur" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-savchenkovaleriy-big-sur.icns")
     sha256 "975288f91608bf38ba55ad7a13502dc74dacf647f2e2f7eb336d7d470cc9e16d"
   end
 
   resource "modern-icon-bokehlicia-captiva" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-bokehlicia-captiva.icns")
     sha256 "8534f309b72812ba99375ebe2eb1d814bd68aec8898add2896594f4eecb10238"
   end
 
   resource "modern-icon-nuvola" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-nuvola.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-nuvola.icns")
     sha256 "c3701e25ff46116fd694bc37d8ccec7ad9ae58bb581063f0792ea3c50d84d997"
   end
 
   resource "modern-icon-black-gnu-head" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-black-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-gnu-head.icns")
     sha256 "9ac25aaa986b53d268e94d24bb878689c290b237a7810790dead9162e6ddf54b"
   end
 
   resource "modern-icon-dragon" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-dragon.icns")
     sha256 "a0a624e6a08971f2f9220d2a3aaa79e1f8aecc85df8a522ebb40310c54699c40"
   end
 
   resource "modern-icon-black-dragon" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-black-dragon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-black-dragon.icns")
     sha256 "2844b2e57f87d9bd183c572d24c8e5a5eb8ecfc238a8714d2c6e3ea51659c92a"
   end
 
   resource "modern-icon-emacs-icon1" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon1.icns")
     sha256 "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0"
   end
 
   resource "modern-icon-emacs-icon2" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon2.icns")
     sha256 "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963"
   end
 
   resource "modern-icon-emacs-icon3" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon3.icns")
     sha256 "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf"
   end
 
   resource "modern-icon-emacs-icon4" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon4.icns")
     sha256 "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135"
   end
 
   resource "modern-icon-emacs-icon5" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon5.icns")
     sha256 "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778"
   end
 
   resource "modern-icon-emacs-icon6" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon6.icns")
     sha256 "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0"
   end
 
   resource "modern-icon-emacs-icon7" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon7.icns")
     sha256 "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c"
   end
 
   resource "modern-icon-emacs-icon8" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon8.icns")
     sha256 "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0"
   end
 
   resource "modern-icon-emacs-icon9" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-EmacsIcon9.icns")
     sha256 "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e"
   end
 
   resource "modern-icon-emacs-card-blue-deep" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-blue-deep.icns")
     sha256 "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9"
   end
 
   resource "modern-icon-emacs-card-british-racing-green" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-british-racing-green.icns")
     sha256 "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5"
   end
 
   resource "modern-icon-emacs-card-carmine" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-carmine.icns")
     sha256 "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9"
   end
 
   resource "modern-icon-emacs-card-green" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-emacs-card-green.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-emacs-card-green.icns")
     sha256 "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7"
   end
 
   resource "modern-icon-doom" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-doom.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom.icns")
     sha256 "39378a10b3d7e804461eec8bb9967de0cec7b8f1151150bbe2ba16f21001722b"
   end
 
   resource "modern-icon-doom3" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-doom3.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom3.icns")
     sha256 "3ac398d8d691687320d3a88cd8e634c8cfb7ca358bfe6c30108667f2486438b3"
   end
 
   resource "modern-icon-doom-cacodemon" do
-    url EmacsHeadAT30.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
+    url ResourcesResolver.get_resource_url("icons/modern-icon-doom-cacodemon.icns")
     sha256 "5a8d53896f72992bc7158aaaa47665df4009be646deee39af6f8e76893568728"
   end
 
   resource "retro-icon-emacs-logo" do
-    url EmacsHeadAT30.get_resource_url("icons/retro-icon-emacs-logo.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-emacs-logo.icns")
     sha256 "0d7100faa68c17d012fe9309f9496b8d530946c324cb7598c93a4c425326ff97"
   end
 
   resource "retro-icon-gnu-head" do
-    url EmacsHeadAT30.get_resource_url("icons/retro-icon-gnu-head.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-head.icns")
     sha256 "cfca2ff0214cff47167f634a5b9f8c402b488796f79ded23f93ec505f78b2f2f"
   end
 
   resource "retro-icon-gnu-meditate-levitate" do
-    url EmacsHeadAT30.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-gnu-meditate-levitate.icns")
     sha256 "5424582f0a4c1998aa91eb8185e1d41961cbc9605dbcea8a037c602587b14998"
   end
 
   resource "retro-icon-sink-bw" do
-    url EmacsHeadAT30.get_resource_url("icons/retro-icon-sink-bw.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink-bw.icns")
     sha256 "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571"
   end
 
   resource "retro-icon-sink" do
-    url EmacsHeadAT30.get_resource_url("icons/retro-icon-sink.icns")
+    url ResourcesResolver.get_resource_url("icons/retro-icon-sink.icns")
     sha256 "be0ee790589a3e49345e1894050678eab2c75272a8d927db46e240a2466c6abc"
   end
 
@@ -476,14 +469,14 @@ class EmacsHeadAT30 < Formula
   # Reference: https://github.com/d12frosted/homebrew-emacs-plus/issues/119
   if build.with? "no-frame-refocus"
     patch do
-      url EmacsHeadAT30.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
+      url ResourcesResolver.get_resource_url("patches/0001-No-frame-refocus-cocoa.patch")
       sha256 "f004e6e65b969bbe83f5d6d53e4ba0e020631959da9ef9682479f7eeb09becd1"
     end
   end
 
   if build.with? "pdumper"
     patch do
-      url EmacsHeadAT30.get_resource_url("patches/0003-Pdumper-size-increase.patch")
+      url ResourcesResolver.get_resource_url("patches/0003-Pdumper-size-increase.patch")
       sha256 "38440720948f5144399cc700da5e40872cf0011cf2654fbb571684429d2162a1"
     end
   end
@@ -496,18 +489,18 @@ class EmacsHeadAT30 < Formula
 
   if build.with? "poll"
     patch do
-      url EmacsHeadAT30.get_resource_url("patches/0011-Poll.patch")
+      url ResourcesResolver.get_resource_url("patches/0011-Poll.patch")
       sha256 "052eacac5b7bd86b466f9a3d18bff9357f2b97517f463a09e4c51255bdb14648"
     end
   end
 
   patch do
-    url EmacsHeadAT30.get_resource_url("patches/0005-System-appearance.patch")
+    url ResourcesResolver.get_resource_url("patches/0005-System-appearance.patch")
     sha256 "d6ee159839b38b6af539d7b9bdff231263e451c1fd42eec0d125318c9db8cd92"
   end
 
   patch do
-    url EmacsHeadAT30.get_resource_url("patches/0008-Fix-window-role.patch")
+    url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 

--- a/Library/ResourcesResolver.rb
+++ b/Library/ResourcesResolver.rb
@@ -1,0 +1,21 @@
+class ResourcesResolver
+  def self.get_resource_url(resource)
+    base_url = "https://raw.githubusercontent.com"
+    repo   = ENV['HOMEBREW_GITHUB_REPOSITORY']
+    owner  = ENV['HOMEBREW_GITHUB_REPOSITORY_OWNER']
+    branch = ENV['HOMEBREW_GITHUB_REF']
+
+    if repo
+      if branch
+        # on a branch
+        [base_url, owner, repo, branch.sub("refs/heads/", ""), resource].join("/")
+      else
+        # on master
+        [base_url, owner, repo, "master", resource].join("/")
+      end
+    else
+      # local run
+      "file:///" + Dir.pwd + "/" + resource
+    end
+  end
+end


### PR DESCRIPTION
get_resource_url now lives in its own class. Local files are also supported. To build locally, cd into homebrew-emacs-head folder and run (e.g.):

` brew install Formula/emacs-head@29.rb --with-cocoa`