### PR TITLE
Change BLOCK_ALIGN from 1 << 10 to 1 << 15 on emacs-head@30

### DIFF
--- a/Formula/emacs-head@30.rb
+++ b/Formula/emacs-head@30.rb
@@ -102,6 +102,11 @@ class EmacsHeadAT30 < EmacsBase
     sha256 "052eacac5b7bd86b466f9a3d18bff9357f2b97517f463a09e4c51255bdb14648"
   end
 
+  resource "0012-BLOCK_ALIGN.patch" do
+    url ResourcesResolver.get_resource_url("patches/0012-BLOCK_ALIGN.patch")
+    sha256 "f2cc1832f260e86707dc2470c08e8f12c038db06b1f028769a26ebbece11a49e"
+  end
+
   # Icons
   load_icons
 
@@ -146,6 +151,11 @@ class EmacsHeadAT30 < EmacsBase
   patch do
     url ResourcesResolver.get_resource_url("patches/0008-Fix-window-role.patch")
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
+  end
+
+  patch do
+    url ResourcesResolver.get_resource_url("patches/0012-BLOCK_ALIGN.patch")
+    sha256 "f2cc1832f260e86707dc2470c08e8f12c038db06b1f028769a26ebbece11a49e"
   end
 
   def install

--- a/patches/0012-BLOCK_ALIGN.patch
+++ b/patches/0012-BLOCK_ALIGN.patch
@@ -1,0 +1,17 @@
+diff --git a/src/alloc.c b/src/alloc.c
+index c77bdc6372d..f455260c3b0 100644
+--- a/src/alloc.c
++++ b/src/alloc.c
+@@ -1087,11 +1087,7 @@ lisp_free (void *block)
+    BLOCK_BYTES and guarantees they are aligned on a BLOCK_ALIGN boundary.  */
+
+ /* Byte alignment of storage blocks.  */
+-#ifdef HAVE_UNEXEC
+-# define BLOCK_ALIGN (1 << 10)
+-#else  /* !HAVE_UNEXEC */
+-# define BLOCK_ALIGN (1 << 15)
+-#endif
++#define BLOCK_ALIGN (1 << 15)
+ verify (POWER_OF_2 (BLOCK_ALIGN));
+
+ /* Use aligned_alloc if it or a simple substitute is available.


### PR DESCRIPTION
This seems to speed up sweep_conses by 50%. See:
- https://tdodge.consulting/blog/living-the-emacs-garbage-collection-dream
- https://lists.gnu.org/archive/html/emacs-devel/2022-10/msg02174.html