### PR TITLE
Add better message warning for deprecated option

### DIFF
--- a/.github/workflows/emacs-30.yml
+++ b/.github/workflows/emacs-30.yml
@@ -28,9 +28,9 @@ jobs:
         os: [macos-12, macos-13]
         build_opts:
           # All options (imagemagick@7)
-          - '--with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets --with-tree-sitter --with-poll'
+          - '--with-cocoa --with-imagemagick --with-pdumper --with-xwidgets --with-tree-sitter --with-poll'
           # All options (imagemagick@7) + native-comp support
-          - '--with-cocoa --with-no-frame-refocus --with-imagemagick --with-pdumper --with-xwidgets --with-tree-sitter --with-native-comp --with-poll'
+          - '--with-cocoa --with-imagemagick --with-pdumper --with-xwidgets --with-tree-sitter --with-native-comp --with-poll'
 
     env:
       HOMEBREW_EMACS_HEAD_GITHUB_REPOSITORY: ${{ github.repository }}

--- a/Formula/emacs-head@30.rb
+++ b/Formula/emacs-head@30.rb
@@ -117,7 +117,7 @@ class EmacsHeadAT30 < EmacsBase
   # https://github.com/emacs-mirror/emacs/commit/5427ef23b8b3ef52faf4ab1e8401303220c2d1d1
   if build.with? "no-frame-refocus"
     # Show a warning to the user
-    opoo "[DEPRECATED] This option is not required anymore in emacs-head@30"
+    opoo "The option --with-no-frame-refocus is not required anymore in emacs-head@30."
   end
 
   if build.with? "pdumper"


### PR DESCRIPTION
Remove --with-no-frame-refocus option from emacs-head@30 CI