### PR TITLE
Add m4 as dependency for Emacs

### DIFF
--- a/Formula/emacs-head@29.rb
+++ b/Formula/emacs-head@29.rb
@@ -20,6 +20,7 @@ class EmacsHeadAT29 < EmacsBase
   depends_on "cmake"      => :build
   depends_on "pkg-config" => :build
   depends_on "gcc"        => :build
+  depends_on "m4"         => :build
   depends_on "giflib"
   depends_on "gnutls"     => :recommended
   depends_on "librsvg"    => :recommended

--- a/Formula/emacs-head@30.rb
+++ b/Formula/emacs-head@30.rb
@@ -14,6 +14,7 @@ class EmacsHeadAT30 < EmacsBase
   depends_on "cmake"      => :build
   depends_on "pkg-config" => :build
   depends_on "gcc"        => :build
+  depends_on "m4"         => :build
   depends_on "giflib"
   depends_on "gnutls"     => :recommended
   depends_on "librsvg"    => :recommended

--- a/Formula/emacs-head@31.rb
+++ b/Formula/emacs-head@31.rb
@@ -13,6 +13,7 @@ class EmacsHeadAT31 < EmacsBase
   depends_on "cmake"      => :build
   depends_on "pkg-config" => :build
   depends_on "gcc"        => :build
+  depends_on "m4"         => :build
   depends_on "giflib"
   depends_on "gnutls"     => :recommended
   depends_on "librsvg"    => :recommended


### PR DESCRIPTION
I'm facing the same error with emacs-head https://github.com/d12frosted/homebrew-emacs-plus/issues/728