### PR TITLE
Fix the mps feature for emacs@31

### DIFF
--- a/Formula/emacs-head@31.rb
+++ b/Formula/emacs-head@31.rb
@@ -165,16 +165,9 @@ class EmacsHeadAT31 < EmacsBase
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
-  if build.with? "mps"
-    patch do
-      url ResourcesResolver.get_resource_url("patches/0012-BLOCK_ALIGN-30.patch")
-      sha256 "f2cc1832f260e86707dc2470c08e8f12c038db06b1f028769a26ebbece11a49e"
-    end
-  else
-    patch do
-      url ResourcesResolver.get_resource_url("patches/0012-BLOCK_ALIGN.patch")
-      sha256 "20867fec025e1c571635512fb790af0fbafc089b0b656dc8ece9d0ed8d3e6a6b"
-    end
+  patch do
+    url ResourcesResolver.get_resource_url("patches/0012-BLOCK_ALIGN.patch")
+    sha256 "20867fec025e1c571635512fb790af0fbafc089b0b656dc8ece9d0ed8d3e6a6b"
   end
 
   def install

--- a/Formula/emacs-head@31.rb
+++ b/Formula/emacs-head@31.rb
@@ -107,11 +107,6 @@ class EmacsHeadAT31 < EmacsBase
     sha256 "1f8423ea7e6e66c9ac6dd8e37b119972daa1264de00172a24a79a710efcb8130"
   end
 
-  resource "0011-Poll-30.patch" do
-    url ResourcesResolver.get_resource_url("patches/0011-Poll-30.patch")
-    sha256 "59e876f82e6fd8e4583bc2456339eda4f989c86b1e16a02b0726702e95f60825"
-  end
-
   resource "0012-BLOCK_ALIGN.patch" do
     url ResourcesResolver.get_resource_url("patches/0012-BLOCK_ALIGN.patch")
     sha256 "20867fec025e1c571635512fb790af0fbafc089b0b656dc8ece9d0ed8d3e6a6b"


### PR DESCRIPTION
The MPS development branch recently merged in master so we no longer need to use the old block align patch.