### PR TITLE
Update to Emacs 30.1 release

### DIFF
--- a/Formula/emacs-head@30.rb
+++ b/Formula/emacs-head@30.rb
@@ -2,10 +2,10 @@
 require_relative "../Library/EmacsBase"
 
 class EmacsHeadAT30 < EmacsBase
-  url "https://alpha.gnu.org/gnu/emacs/pretest/emacs-30.1-rc1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-30.1-rc1.tar.xz"
-  sha256 "6bf42484eb70a71d9bd9332f44ef32873062160f41d5561b6a6b21f5f9da1e91"
-  version "30.1-rc1"
+  url "https://ftp.gnu.org/gnu/emacs/emacs-30.1.tar.xz"
+  mirror "https://ftpmirror.gnu.org/emacs/emacs-30.1.tar.xz"
+  sha256 "6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f"
+  version "30.1"
   revision 1
 
   depends_on "autoconf"   => :build

--- a/README.org
+++ b/README.org
@@ -38,7 +38,7 @@ This formula currently supports:
 - GNU Emacs 27.2 (or emacs-27 branch)
 - GNU Emacs 28.2 (or emacs-28 branch)
 - GNU Emacs 29.4 (or emacs-29 branch)
-- GNU Emacs 30.1-rc1 (emacs-30 branch)
+- GNU Emacs 30.1 (or emacs-30 branch)
 - GNU Emacs HEAD (currently 31.0.50)
 
 ** Installation


### PR DESCRIPTION
Updated to the 30.1 release tarball, following the example from the 29 formula.