### PR TITLE
Update feature branch for MPS development

### DIFF
--- a/Formula/emacs-head@31.rb
+++ b/Formula/emacs-head@31.rb
@@ -86,7 +86,7 @@ class EmacsHeadAT31 < EmacsBase
   end
 
   if build.with? "mps"
-    url "https://github.com/emacs-mirror/emacs.git", :branch => "feature/igc"
+    url "https://github.com/emacs-mirror/emacs.git", :branch => "feature/igc3"
     depends_on "libmps"
   else
     url "https://github.com/emacs-mirror/emacs.git"


### PR DESCRIPTION
The developers working on MPS are clearing unnecessary artifacts out of the branch, and are working from clean branches igc2 and then igc3, which will be used for development going forward.