### PR TITLE
[fix] Skip ns color initialization in batch mode

### DIFF
--- a/Formula/emacs-head@31.rb
+++ b/Formula/emacs-head@31.rb
@@ -133,7 +133,7 @@ class EmacsHeadAT31 < EmacsBase
   # https://github.com/emacs-mirror/emacs/commit/b7aca342e69c398cc8c3a7b8557ccf19cf7d444b
   patch do
     url ResourcesResolver.get_resource_url("patches/0014-Skip_ns_color_initialization_in_batch_mode.patch")
-    sha256 "fa02356ed53bb8c229027d437259ec3af67399de42e8752071088f04eb2c5fbb"
+    sha256 "eae3f6d1442b3c9831046799cb72fb984e1653ba2537d236a8f58a1764807137"
   end
 
   def install

--- a/patches/0014-Skip_ns_color_initialization_in_batch_mode.patch
+++ b/patches/0014-Skip_ns_color_initialization_in_batch_mode.patch
@@ -14,15 +14,14 @@ not have the full color list.  This is acceptable because batch mode
 has no display and color queries are meaningless there.
 
 diff --git a/src/emacs.c b/src/emacs.c
-index 8e3d528dcea..01a971095bd 100644
+index 11fe567737a..b8d5758eada 100644
 --- a/src/emacs.c
 +++ b/src/emacs.c
-@@ -2066,7 +2066,7 @@ Using an Emacs configured with --with-x-toolkit=lucid does not have this problem
-
+@@ -2292,7 +2292,7 @@ Using an Emacs configured with --with-x-toolkit=lucid does not have this problem
  #ifdef HAVE_NS
-   /* For early calls to ns_lisp_to_color or Fns_list_colors.  */
+   /* For early calls to ns_lisp_to_color or Fns_list_colors.
+      Must follow init_callproc which sets data-directory.  */
 -  if (!dump_mode)
 +  if (!dump_mode && !noninteractive)
      ns_init_colors ();
-
-   if (!noninteractive)
+ #endif


### PR DESCRIPTION
Skip color initialization in batch mode to avoid unnecessary calls when no display is present.